### PR TITLE
Automatically find library imports

### DIFF
--- a/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
@@ -29,11 +29,9 @@ import io.papermc.paperweight.tasks.patchremap.ApplyAccessTransform
 import io.papermc.paperweight.util.Constants
 import io.papermc.paperweight.util.cache
 import io.papermc.paperweight.util.fileExists
-import io.papermc.paperweight.util.path
 import io.papermc.paperweight.util.registering
 import io.papermc.paperweight.util.set
 import java.nio.file.Path
-import kotlin.io.path.exists
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.*
@@ -95,8 +93,8 @@ open class AllTasks(
         spigotServerDir.set(patchSpigotServer.flatMap { it.outputDir })
         sourceMcDevJar.set(decompileJar.flatMap { it.outputJar })
         mcLibrariesDir.set(downloadMcLibraries.flatMap { it.sourcesOutputDir })
-        libraryImports.set(extension.paper.libraryClassImports)
-        mcdevImports.set(extension.paper.mcdevClassImports.flatMap { project.provider { if (it.path.exists()) it else null } })
+        libraryImports.set(extension.paper.libraryClassImports.fileExists(project))
+        mcdevImports.set(extension.paper.mcdevClassImports.fileExists(project))
 
         outputDir.set(extension.paper.paperServerDir)
     }

--- a/paperweight-core/src/main/kotlin/taskcontainers/SpigotTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/SpigotTasks.kt
@@ -29,6 +29,7 @@ import io.papermc.paperweight.tasks.*
 import io.papermc.paperweight.util.Constants
 import io.papermc.paperweight.util.cache
 import io.papermc.paperweight.util.download
+import io.papermc.paperweight.util.fileExists
 import io.papermc.paperweight.util.registering
 import io.papermc.paperweight.util.set
 import java.nio.file.Path
@@ -51,8 +52,8 @@ open class SpigotTasks(
         dependsOn(initSubmodules)
         classSrg.set(extension.craftBukkit.mappingsDir.file(buildDataInfo.map { it.classMappings }))
         memberSrg.set(extension.craftBukkit.mappingsDir.file(buildDataInfo.map { it.memberMappings }))
-        additionalClassEntriesSrg.set(extension.paper.additionalSpigotClassMappings)
-        additionalMemberEntriesSrg.set(extension.paper.additionalSpigotMemberMappings)
+        additionalClassEntriesSrg.set(extension.paper.additionalSpigotClassMappings.fileExists(project))
+        additionalMemberEntriesSrg.set(extension.paper.additionalSpigotMemberMappings.fileExists(project))
     }
 
     val inspectVanillaJar by tasks.registering<InspectVanillaJar> {
@@ -104,7 +105,7 @@ open class SpigotTasks(
 
     val patchMappings by tasks.registering<PatchMappings> {
         inputMappings.set(cleanupMappings.flatMap { it.outputMappings })
-        patch.set(extension.paper.mappingsPatch)
+        patch.set(extension.paper.mappingsPatch.fileExists(project))
 
         outputMappings.set(cache.resolve(Constants.PATCHED_SPIGOT_MOJANG_YARN_MAPPINGS))
     }
@@ -131,7 +132,7 @@ open class SpigotTasks(
     val patchCraftBukkitPatches by tasks.registering<ApplyRawDiffPatches> {
         dependsOn(initSubmodules)
         inputDir.set(extension.craftBukkit.patchDir)
-        patchDir.set(extension.paper.craftBukkitPatchPatchesDir)
+        patchDir.set(extension.paper.craftBukkitPatchPatchesDir.fileExists(project))
     }
 
     val patchCraftBukkit by tasks.registering<ApplyDiffPatches> {
@@ -146,13 +147,13 @@ open class SpigotTasks(
     val patchSpigotApiPatches by tasks.registering<ApplyRawDiffPatches> {
         dependsOn(initSubmodules)
         inputDir.set(extension.spigot.bukkitPatchDir)
-        patchDir.set(extension.paper.spigotApiPatchPatchesDir)
+        patchDir.set(extension.paper.spigotApiPatchPatchesDir.fileExists(project))
     }
 
     val patchSpigotServerPatches by tasks.registering<ApplyRawDiffPatches> {
         dependsOn(initSubmodules)
         inputDir.set(extension.spigot.craftBukkitPatchDir)
-        patchDir.set(extension.paper.spigotServerPatchPatchesDir)
+        patchDir.set(extension.paper.spigotServerPatchPatchesDir.fileExists(project))
     }
 
     val patchSpigotApi by tasks.registering<ApplyGitPatches> {

--- a/paperweight-lib/src/main/kotlin/tasks/PatchMappings.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/PatchMappings.kt
@@ -42,8 +42,8 @@ abstract class PatchMappings : DefaultTask() {
     @get:InputFile
     abstract val inputMappings: RegularFileProperty
 
-    @get:InputFile
     @get:Optional
+    @get:InputFile
     abstract val patch: RegularFileProperty
 
     @get:OutputFile

--- a/paperweight-lib/src/main/kotlin/util/McDev.kt
+++ b/paperweight-lib/src/main/kotlin/util/McDev.kt
@@ -137,7 +137,7 @@ object McDev {
                     val split = line.split(' ')
                     val libFileName = libFiles.firstOrNull { it.name.startsWith(split[0]) }?.name
                         ?: throw PaperweightException("Failed to read library line '$line', no library file was found.")
-                    LibraryImport(libFileName, split[1])
+                    LibraryImport(libFileName, split[1].removeSuffix(".java").replace('.', '/') + ".java")
                 }
         }
 

--- a/paperweight-lib/src/main/kotlin/util/McDev.kt
+++ b/paperweight-lib/src/main/kotlin/util/McDev.kt
@@ -25,8 +25,11 @@ package io.papermc.paperweight.util
 import io.papermc.paperweight.PaperweightException
 import java.nio.file.Path
 import kotlin.io.path.*
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
 
 object McDev {
+    private val logger: Logger = Logging.getLogger(McDev::class.java)
 
     private val bannedClasses = setOf(
         "KeyedObject",
@@ -35,13 +38,15 @@ object McDev {
     )
 
     fun importMcDev(patches: Iterable<Path>, decompJar: Path, libraryImports: Path?, libraryDir: Path?, additionalClasses: Path?, targetDir: Path) {
-        val importMcDev = readMcDevNames(patches, additionalClasses).asSequence()
+        val patchLines = readPatchLines(patches)
+
+        val importMcDev = readMcDevNames(patchLines, additionalClasses).asSequence()
             .map { targetDir.resolve("net/minecraft/$it.java") }
             .filter { !it.exists() }
             .filterNot { file -> bannedClasses.any { file.toString().contains(it) } }
             .toSet()
 
-        println("Importing ${importMcDev.size} classes from vanilla...")
+        logger.lifecycle("Importing {} classes from vanilla...", importMcDev.size)
 
         decompJar.openZip().use { zipFile ->
             for (file in importMcDev) {
@@ -60,48 +65,57 @@ object McDev {
             }
         }
 
-        // Import library classes
-        val libraryLines = libraryImports?.readLines() ?: emptyList()
-        if (libraryLines.isEmpty()) {
-            return
-        }
-
         val libFiles = libraryDir?.listDirectoryEntries("*-sources.jar") ?: return
         if (libFiles.isEmpty()) {
             throw PaperweightException("No library files found")
         }
 
-        for (line in libraryLines) {
-            val (libraryName, filePath) = line.split(" ")
-            val libFile = libFiles.firstOrNull { it.name.startsWith(libraryName) }
-                ?: throw PaperweightException("Failed to find library: $libraryName for class $filePath")
+        // Import library classes
+        val imports = findLibraries(libraryImports, libFiles, patchLines)
+        logger.lifecycle("Importing {} classes from library sources...", imports.size)
 
-            val outputFile = targetDir.resolve(filePath)
+        for ((libraryFileName, importFilePath) in imports) {
+            val libFile = libFiles.firstOrNull { it.name == libraryFileName }
+                ?: throw PaperweightException("Failed to find library: $libraryFileName for class $importFilePath")
+
+            val outputFile = targetDir.resolve(importFilePath)
             if (outputFile.exists()) {
                 continue
             }
             outputFile.parent.createDirectories()
 
             libFile.openZip().use { zipFile ->
-                val libEntry = zipFile.getPath(filePath)
+                val libEntry = zipFile.getPath(importFilePath)
                 libEntry.copyTo(outputFile)
             }
         }
     }
 
-    private fun readMcDevNames(patches: Iterable<Path>, additionalClasses: Path?): Set<String> {
+    private fun readPatchLines(patches: Iterable<Path>): Set<String> {
         val result = hashSetOf<String>()
 
-        val prefix = "+++ b/src/main/java/net/minecraft/"
-        val suffix = ".java"
+        val prefix = "+++ b/src/main/java/"
 
         for (patch in patches) {
             patch.useLines { lines ->
                 lines.filter { it.startsWith(prefix) }
                     .filterNot { file -> bannedClasses.any { file.contains(it) } }
-                    .mapTo(result) { it.substring(prefix.length, it.length - suffix.length) }
+                    .mapTo(result) { it.substring(prefix.length, it.length) }
             }
         }
+
+        return result
+    }
+
+    private fun readMcDevNames(patchLines: Set<String>, additionalClasses: Path?): Set<String> {
+        val result = hashSetOf<String>()
+
+        val patchLinesPrefix = "net/minecraft/"
+        val suffix = ".java"
+
+        patchLines.filter { it.startsWith(patchLinesPrefix) }
+            .filterNot { file -> bannedClasses.any { file.contains(it) } }
+            .mapTo(result) { it.substring(patchLinesPrefix.length, it.length - suffix.length) }
 
         additionalClasses?.useLines { lines ->
             lines.filterNot { it.startsWith("#") }
@@ -112,4 +126,51 @@ object McDev {
 
         return result
     }
+
+    private fun findLibraries(libraryImports: Path?, libFiles: List<Path>, patchLines: Set<String>): Set<LibraryImport> {
+        val result = hashSetOf<LibraryImport>()
+
+        // Imports from library-imports.txt
+        libraryImports?.useLines { lines ->
+            lines.filterNot { it.startsWith('#') }
+                .mapTo(result) { line ->
+                    val split = line.split(' ')
+                    val libFileName = libFiles.firstOrNull { it.name.startsWith(split[0]) }?.name
+                        ?: throw PaperweightException("Failed to read library line '$line', no library file was found.")
+                    LibraryImport(libFileName, split[1])
+                }
+        }
+
+        // Scan patches for necessary imports
+        result += findNeededLibraryImports(patchLines, libFiles)
+
+        return result
+    }
+
+    private fun findNeededLibraryImports(patchLines: Set<String>, libFiles: List<Path>): Set<LibraryImport> {
+        val knownImportMap = findPossibleLibraryImports(libFiles)
+            .associateBy { it.importFilePath }
+        val prefix = "+++ b/src/main/java/"
+        return patchLines.map { it.substringAfter(prefix) }
+            .mapNotNull { knownImportMap[it] }
+            .toSet()
+    }
+
+    private fun findPossibleLibraryImports(libFiles: List<Path>): Collection<LibraryImport> {
+        val found = hashSetOf<LibraryImport>()
+        val suffix = ".java"
+        libFiles.map { libFile ->
+            libFile.openZip().use { zipFile ->
+                zipFile.walk()
+                    .filter { it.isRegularFile() && it.name.endsWith(suffix) }
+                    .map { sourceFile ->
+                        LibraryImport(libFile.name, sourceFile.toString().substring(1))
+                    }
+                    .forEach(found::add)
+            }
+        }
+        return found
+    }
+
+    private data class LibraryImport(val libraryFileName: String, val importFilePath: String)
 }

--- a/paperweight-lib/src/main/kotlin/util/utils.kt
+++ b/paperweight-lib/src/main/kotlin/util/utils.kt
@@ -48,7 +48,6 @@ import org.cadixdev.lorenz.model.MemberMapping
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileSystemLocation
-import org.gradle.api.file.FileSystemLocationProperty
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
@@ -78,7 +77,7 @@ fun ProjectLayout.initSubmodules() {
     Git(projectDirectory.path)("submodule", "update", "--init").executeOut()
 }
 
-fun <T : FileSystemLocation> FileSystemLocationProperty<out T>.fileExists(project: Project): Provider<out T?> {
+fun <T : FileSystemLocation> Provider<out T>.fileExists(project: Project): Provider<out T?> {
     return flatMap { project.provider { it.takeIf { f -> f.path.exists() } } }
 }
 


### PR DESCRIPTION
General concept should be fine and is well tested in my Toothpick fork, however I have yet to test these changes in Paperweight.