### PR TITLE
Apply additional access transformers earlier so that they are applied to classes we don't import into the source tree

### DIFF
--- a/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
@@ -46,9 +46,14 @@ open class AllTasks(
     extension: PaperweightCoreExtension = project.ext,
 ) : SpigotTasks(project) {
 
+    val mergeAdditionalAts by tasks.registering<MergeAccessTransforms> {
+        inputFiles.add(mergeGeneratedAts.flatMap { it.outputFile })
+        inputFiles.add(extension.paper.additionalAts)
+    }
+
     val applyMergedAt by tasks.registering<ApplyAccessTransform> {
         inputJar.set(fixJar.flatMap { it.outputJar })
-        atFile.set(mergeGeneratedAts.flatMap { it.outputFile })
+        atFile.set(mergeAdditionalAts.flatMap { it.outputFile })
     }
 
     val copyResources by tasks.registering<CopyResources> {
@@ -91,8 +96,6 @@ open class AllTasks(
         mcLibrariesDir.set(downloadMcLibraries.flatMap { it.sourcesOutputDir })
         libraryImports.set(extension.paper.libraryClassImports)
         mcdevImports.set(extension.paper.mcdevClassImports.flatMap { project.provider { if (it.path.exists()) it else null } })
-        apiDir.set(extension.paper.paperApiDir)
-        additionalAts.set(extension.paper.additionalAts.flatMap { project.provider { it.takeIf { f -> f.path.exists() } } })
 
         outputDir.set(extension.paper.paperServerDir)
     }

--- a/paperweight-lib/src/main/kotlin/tasks/ApplyPaperPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ApplyPaperPatches.kt
@@ -25,7 +25,6 @@ package io.papermc.paperweight.tasks
 import com.github.salomonbrys.kotson.fromJson
 import io.papermc.paperweight.util.*
 import java.nio.file.Path
-import javax.inject.Inject
 import kotlin.io.path.*
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -34,7 +33,6 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.workers.WorkerExecutor
 
 abstract class ApplyPaperPatches : ControllableOutputTask() {
 

--- a/paperweight-lib/src/main/kotlin/tasks/ApplyPaperPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ApplyPaperPatches.kt
@@ -67,18 +67,8 @@ abstract class ApplyPaperPatches : ControllableOutputTask() {
     @get:InputFile
     abstract val mcdevImports: RegularFileProperty
 
-    @get:InputDirectory
-    abstract val apiDir: DirectoryProperty
-
-    @get:Optional
-    @get:InputFile
-    abstract val additionalAts: RegularFileProperty
-
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
-
-    @get:Inject
-    abstract val workerExecutor: WorkerExecutor
 
     override fun init() {
         printOutput.convention(true)
@@ -128,11 +118,6 @@ abstract class ApplyPaperPatches : ControllableOutputTask() {
 
             git("add", ".").executeSilently()
             git("commit", "-m", "Initial", "--author=Initial Source <auto@mated.null>").executeSilently()
-
-            PaperAt.apply(workerExecutor, apiDir.path, outputDir.path, additionalAts.pathOrNull)
-            git("add", ".").runSilently()
-            git("commit", "-m", "AT", "--author=AT <auto@mated.null>").runSilently()
-
             git("tag", "base").executeSilently()
 
             applyGitPatches(git, target, outputFile, patchDir.path, printOutput.get())


### PR DESCRIPTION
The downside of this is that there will not be a git blame showing the transform was applied.

This also removes the dependency that `applyServerPatches` had on `applyApiPatches` output, which was causing deprecation warnings due to no task dependency being declared.