### PR TITLE
Delete nms-patches directory

### DIFF
--- a/paperweight-lib/src/main/kotlin/tasks/ApplyPaperPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ApplyPaperPatches.kt
@@ -118,6 +118,9 @@ abstract class ApplyPaperPatches : ControllableOutputTask() {
                 git("mv", "-f", obfFile.toString(), deobfFile.toString()).runSilently(silenceErr = true)
             }
 
+            val craftBukkitNMSPatches = outputFile.resolve("nms-patches")
+            craftBukkitNMSPatches.deleteRecursively()
+
             git("add", ".").executeSilently()
             git("commit", "-m", "Initial", "--author=Initial Source <auto@mated.null>").executeSilently()
             git("tag", "-d", "base").runSilently(silenceErr = true)


### PR DESCRIPTION
This was done in the old scripts (as part of `importmcdev.sh` for some reason: https://github.com/PaperMC/Paper/blob/e04368045e2fe8e53a7b686e9bfb7c41766267be/scripts/importmcdev.sh#L123)