### PR TITLE
Ignore gitignore when adding files in automation

### DIFF
--- a/paperweight-lib/src/main/kotlin/tasks/ApplyDiffPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ApplyDiffPatches.kt
@@ -106,7 +106,7 @@ abstract class ApplyDiffPatches : ControllableOutputTask() {
                 }
             }
 
-            git("add", "src").setupOut().execute()
+            git("add", "--force", "src").setupOut().execute()
             git("commit", "-m", "Vanilla $ ${Date()}", "--author=Vanilla <auto@mated.null>").setupOut().execute()
 
             // Apply patches
@@ -121,7 +121,7 @@ abstract class ApplyDiffPatches : ControllableOutputTask() {
                 git("apply", "--ignore-whitespace", "--directory=$dirPrefix", file.absolutePathString()).setupOut().execute()
             }
 
-            git("add", "src").setupOut().execute()
+            git("add", "--force", "src").setupOut().execute()
             git("commit", "-m", "CraftBukkit $ ${Date()}", "--author=CraftBukkit <auto@mated.null>").setupOut().execute()
             git("checkout", "-f", "HEAD~2").setupOut().execute()
         } finally {

--- a/paperweight-lib/src/main/kotlin/tasks/ApplyGitPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ApplyGitPatches.kt
@@ -91,7 +91,7 @@ abstract class ApplyGitPatches : ControllableOutputTask() {
 
                 if (unneededFiles.isPresent && unneededFiles.get().size > 0) {
                     unneededFiles.get().forEach { path -> outputDir.path.resolve(path).deleteRecursively() }
-                    git("add", ".").setupOut().run()
+                    git("add", "--force", ".").setupOut().run()
                     git("commit", "-m", "Initial", "--author=Initial Source <auto@mated.null>").setupOut().run()
                 }
 

--- a/paperweight-lib/src/main/kotlin/tasks/ApplyPaperPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ApplyPaperPatches.kt
@@ -121,7 +121,7 @@ abstract class ApplyPaperPatches : ControllableOutputTask() {
 
             unneededFiles.orNull?.forEach { path -> outputFile.resolve(path).deleteRecursively() }
 
-            git("add", ".").executeSilently()
+            git("add", "--force", ".").executeSilently()
             git("commit", "-m", "Initial", "--author=Initial Source <auto@mated.null>").executeSilently()
             git("tag", "-d", "base").runSilently(silenceErr = true)
             git("tag", "base").executeSilently()

--- a/paperweight-lib/src/main/kotlin/tasks/patchremap/PatchApplier.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/patchremap/PatchApplier.kt
@@ -54,13 +54,13 @@ class PatchApplier(
 
     fun commitInitialSource() {
         git("checkout", "-b", unmappedBranch).executeSilently()
-        git("add", ".").executeSilently()
+        git("add", "--force", ".").executeSilently()
         git("commit", "-m", "Initial Source", "--author=Initial <auto@mated.null>").executeSilently()
         git("branch", remappedBranch).executeSilently()
     }
 
     fun commitInitialRemappedSource() {
-        git("add", ".").executeSilently()
+        git("add", "--force", ".").executeSilently()
         git("commit", "-m", "Initial Remapped Source", "--author=Initial <auto@mated.null>").executeSilently()
         git("tag", remappedBaseTag)
     }
@@ -84,7 +84,7 @@ class PatchApplier(
         val time = commitTime ?: throw PaperweightException("commitTime not set")
         clearCommit()
 
-        git("add", ".").executeSilently()
+        git("add", "--force", ".").executeSilently()
         git("commit", "-m", message, "--author=$author", "--date=$time").execute()
     }
 

--- a/paperweight-patcher/src/main/kotlin/tasks/SimpleApplyGitPatches.kt
+++ b/paperweight-patcher/src/main/kotlin/tasks/SimpleApplyGitPatches.kt
@@ -124,7 +124,7 @@ abstract class SimpleApplyGitPatches : ControllableOutputTask() {
             )
         }
 
-        git("add", ".").executeSilently()
+        git("add", "--force", ".").executeSilently()
         git("commit", "--allow-empty", "-m", "Initial", "--author=Initial Source <auto@mated.null>").executeSilently()
         git("tag", "-d", "base").runSilently(silenceErr = true)
         git("tag", "base").executeSilently()


### PR DESCRIPTION
There are idiots like me, who use global gitignore.
While I plan on improving that situation and already disabled global
gitignore for Paper repository, this doesn't stop other's from asking for support/creating issues when they hit it.

This should fix it. For reference, PR fixing it for old scripts:
https://github.com/PaperMC/Paper/pull/5461

Example error that happens when you put `target/` in your global gitignore:
```
Applying: MC-145656 Fix Follow Range Initial Target
Patch failed at 0351 MC-145656 Fix Follow Range Initial Target
If you prefer to skip this patch, run "git am --skip" instead.
To restore the original branch and stop patching, run "git am --abort".
error: invalid object 100644 6cbd2fc4a7041f957966e5b09616e70aae63c0d4 for 'src/main/java/net/minecraft/world/entity/ai/goal/target/NearestAttackableTargetGoal.java'
error: Repository lacks necessary blobs to fall back on 3-way merge.
hint: Use 'git am --show-current-patch=diff' to see the failed patch
```

Confirmed working with my config, by running `./gradlew pTML` and then in Paper repo running `./gradlew clean cC` followed by `./gradlew aP`, after previously patching it to use local paperweight build.

Applied simply by running: `git grep -l 'git("add"' | xargs sed -i 's/git("add"/\0, "--force"/'`