### PR TITLE
Change default mc-dev sources location to be inside the server project

### DIFF
--- a/paperweight-core/src/main/kotlin/PaperweightCore.kt
+++ b/paperweight-core/src/main/kotlin/PaperweightCore.kt
@@ -106,7 +106,7 @@ class PaperweightCore : Plugin<Project> {
                 target,
                 cache.resolve(FINAL_REMAPPED_JAR),
                 tasks.decompileJar.flatMap { it.outputJar },
-                ext.paper.mcDevSourceDir.path,
+                ext.mcDevSourceDir.path,
                 cache.resolve(SERVER_LIBRARIES),
                 ext.paper.reobfPackagesToFix
             ) {

--- a/paperweight-core/src/main/kotlin/extension/PaperExtension.kt
+++ b/paperweight-core/src/main/kotlin/extension/PaperExtension.kt
@@ -23,7 +23,6 @@
 package io.papermc.paperweight.core.extension
 
 import io.papermc.paperweight.util.*
-import io.papermc.paperweight.util.constants.*
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
@@ -41,7 +40,6 @@ open class PaperExtension(objects: ObjectFactory, layout: ProjectLayout) {
     val unmappedSpigotServerPatchDir: DirectoryProperty = objects.dirFrom(baseTargetDir, "patches/server-unmapped")
     val paperApiDir: DirectoryProperty = objects.dirFrom(baseTargetDir, "Paper-API")
     val paperServerDir: DirectoryProperty = objects.dirFrom(baseTargetDir, "Paper-Server")
-    val mcDevSourceDir: DirectoryProperty = objects.directoryProperty().convention(layout.cacheDir(MC_DEV_SOURCES_DIR))
 
     @Suppress("MemberVisibilityCanBePrivate")
     val buildDataDir: DirectoryProperty = objects.dirWithDefault(layout, "build-data")

--- a/paperweight-core/src/main/kotlin/extension/PaperweightCoreExtension.kt
+++ b/paperweight-core/src/main/kotlin/extension/PaperweightCoreExtension.kt
@@ -23,6 +23,7 @@
 package io.papermc.paperweight.core.extension
 
 import io.papermc.paperweight.util.*
+import io.papermc.paperweight.util.constants.*
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
@@ -38,6 +39,8 @@ open class PaperweightCoreExtension(objects: ObjectFactory, layout: ProjectLayou
 
     val minecraftVersion: Property<String> = objects.property()
     val serverProject: Property<Project> = objects.property()
+
+    val mcDevSourceDir: DirectoryProperty = objects.directoryProperty().convention(serverProject.map { it.layout.cacheDir(MC_DEV_SOURCES_DIR) })
 
     @Suppress("MemberVisibilityCanBePrivate")
     val craftBukkit = CraftBukkitExtension(objects, workDir)

--- a/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
@@ -105,7 +105,7 @@ open class AllTasks(
         unneededFiles.value(listOf("nms-patches", "applyPatches.sh", "CONTRIBUTING.md", "makePatches.sh", "README.md"))
 
         outputDir.set(extension.paper.paperServerDir)
-        mcDevSources.set(extension.paper.mcDevSourceDir)
+        mcDevSources.set(extension.mcDevSourceDir)
     }
 
     val applyPatches by tasks.registering<Task> {

--- a/paperweight-patcher/src/main/kotlin/PaperweightPatcherExtension.kt
+++ b/paperweight-patcher/src/main/kotlin/PaperweightPatcherExtension.kt
@@ -49,7 +49,7 @@ open class PaperweightPatcherExtension(private val objects: ObjectFactory, layou
 
     val serverProject: Property<Project> = objects.property()
 
-    val mcDevSourceDir: DirectoryProperty = objects.directoryProperty().convention(layout.cacheDir(MC_DEV_SOURCES_DIR))
+    val mcDevSourceDir: DirectoryProperty = objects.directoryProperty().convention(serverProject.map { it.layout.cacheDir(MC_DEV_SOURCES_DIR) })
 
     val buildDataDir: DirectoryProperty = objects.dirWithDefault(layout, "build-data")
     val devImports: RegularFileProperty = objects.fileFrom(buildDataDir, "dev-imports.txt")


### PR DESCRIPTION
This makes it easier to "Find in files" for the entire server without also searching the rest of gradle caches