### PR TITLE
Apply shadow before trying to access shadowJar

### DIFF
--- a/paperweight-patcher/src/main/kotlin/PaperweightPatcher.kt
+++ b/paperweight-patcher/src/main/kotlin/PaperweightPatcher.kt
@@ -106,6 +106,7 @@ class PaperweightPatcher : Plugin<Project> {
 
             val upstreamData = upstreamDataTask.readUpstreamData()
             val serverProj = patcher.serverProject.forUseAtConfigurationTime().orNull ?: return@afterEvaluate
+            serverProj.apply(plugin = "com.github.johnrengelman.shadow")
 
             generateReobfMappings {
                 inputMappings.pathProvider(upstreamData.map { it.mappings })


### PR DESCRIPTION
This is already done in core: https://github.com/PaperMC/paperweight/blob/main/paperweight-core/src/main/kotlin/PaperweightCore.kt#L99

This fixes `generateReobfMappings` failing to configure when running `./gradlew tasks` before having applied patches