### PR TITLE
Improve mcdev sources generation

### DIFF
--- a/paperweight-lib/src/main/kotlin/util/MakeMcDevSrc.kt
+++ b/paperweight-lib/src/main/kotlin/util/MakeMcDevSrc.kt
@@ -29,10 +29,11 @@ fun makeMcDevSrc(decompileJar: Path, paperSource: Path, target: Path) {
     ensureDeleted(target)
 
     decompileJar.openZip().use { fs ->
+        val root = fs.getPath("/")
         fs.walk().use { stream ->
             stream.forEach { sourceFile ->
                 if (sourceFile.isRegularFile()) {
-                    val sourceFilePath = sourceFile.pathString.removePrefix("/")
+                    val sourceFilePath = sourceFile.relativeTo(root).invariantSeparatorsPathString
 
                     if (!paperSource.resolve(sourceFilePath).isRegularFile()) {
                         val targetFile = target.resolve(sourceFilePath)


### PR DESCRIPTION
I wasn't able to reproduce the issue on my install of Windows, but someone reported having modified files end up in the mcdev sources, this change should reduce chances of things going wrong on various platforms.