### PR TITLE
Automatically stash uncommitted changes

### DIFF
--- a/paperweight-lib/src/main/kotlin/tasks/ApplyGitPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ApplyGitPatches.kt
@@ -110,6 +110,8 @@ abstract class ApplyGitPatches : ControllableOutputTask() {
                 git("tag", "base").executeSilently(silenceErr = true)
 
                 applyGitPatches(git, target, outputDir.path, rootPatchDir, printOutput.get())
+
+                restoreStashedChanges(outputPath)
             }
         } finally {
             if (rootPatchDir != patchDir.pathOrNull) {
@@ -189,6 +191,7 @@ fun recreateCloneDirectory(target: Path) {
     if (target.exists()) {
         if (target.resolve(".git").isDirectory()) {
             val git = Git(target)
+            git("stash").run()
             git("clean", "-fxd").runSilently(silenceErr = true)
             git("reset", "--hard", "HEAD").runSilently(silenceErr = true)
         } else {
@@ -199,5 +202,14 @@ fun recreateCloneDirectory(target: Path) {
         }
     } else {
         target.createDirectories()
+    }
+}
+
+fun restoreStashedChanges(target: Path) {
+    if (target.exists()) {
+        if (target.resolve(".git").isDirectory()) {
+            val git = Git(target)
+            git("stash", "pop").run()
+        }
     }
 }

--- a/paperweight-lib/src/main/kotlin/tasks/ApplyPaperPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ApplyPaperPatches.kt
@@ -148,6 +148,8 @@ abstract class ApplyPaperPatches : ControllableOutputTask() {
             applyGitPatches(git, target, outputFile, patchDir.path, printOutput.get())
 
             makeMcDevSrc(sourceMcDevJar.path, sourceDir, mcDevSources.path)
+
+            restoreStashedChanges(outputFile)
         }
     }
 

--- a/paperweight-patcher/src/main/kotlin/tasks/SimpleApplyGitPatches.kt
+++ b/paperweight-patcher/src/main/kotlin/tasks/SimpleApplyGitPatches.kt
@@ -139,5 +139,7 @@ abstract class SimpleApplyGitPatches : ControllableOutputTask() {
         applyGitPatches(git, target, output, patchDir.pathOrNull, printOutput.get())
 
         makeMcDevSrc(sourceMcDevJar.path, srcDir, mcDevSources.path)
+
+        restoreStashedChanges(output)
     }
 }


### PR DESCRIPTION
Paperweight's current behaviour is to hard reset tracked projects before applying stored patches, which erases unstaged changes without any warning to the user when calling applyPatches. This patch adds convenience functionality to both `paperweight-core` and `paperweight-patcher` to stash uncommitted work while in the process of patching, and apply stashed changes afterwards (Mostly useful for people who are forgetful or don't want to commit half finished changes while fetching upstream)