### PR TITLE
Add remapped jar for bindings resolution

### DIFF
--- a/paperweight-core/src/main/kotlin/taskcontainers/SpigotTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/SpigotTasks.kt
@@ -193,6 +193,7 @@ open class SpigotTasks(
         spigotApiDir.set(patchSpigotApi.flatMap { it.outputDir })
         mappings.set(patchMappings.flatMap { it.outputMappings })
         vanillaJar.set(downloadServerJar.flatMap { it.outputJar })
+        mojangMappedVanillaJar.set(fixJar.flatMap { it.outputJar })
         vanillaRemappedSpigotJar.set(filterSpigotExcludes.flatMap { it.outputZip })
         spigotDeps.from(downloadSpigotDependencies.map { it.outputDir.asFileTree })
         additionalAts.set(extension.paper.additionalAts.fileExists(project))

--- a/paperweight-lib/src/main/kotlin/tasks/RemapSources.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/RemapSources.kt
@@ -54,6 +54,9 @@ abstract class RemapSources : JavaLauncherTask() {
     abstract val vanillaJar: RegularFileProperty
 
     @get:CompileClasspath
+    abstract val mojangMappedVanillaJar: RegularFileProperty
+
+    @get:CompileClasspath
     abstract val vanillaRemappedSpigotJar: RegularFileProperty
 
     @get:InputFile
@@ -116,6 +119,7 @@ abstract class RemapSources : JavaLauncherTask() {
             // Remap sources
             queue.submit(RemapAction::class) {
                 classpath.from(vanillaRemappedSpigotJar.path)
+                classpath.from(mojangMappedVanillaJar.path)
                 classpath.from(vanillaJar.path)
                 classpath.from(spigotApiDir.dir("src/main/java").path)
                 classpath.from(spigotDeps.files.filter { it.toPath().isLibraryJar })
@@ -135,6 +139,7 @@ abstract class RemapSources : JavaLauncherTask() {
             // Remap tests
             queue.submit(RemapAction::class) {
                 classpath.from(vanillaRemappedSpigotJar.path)
+                classpath.from(mojangMappedVanillaJar.path)
                 classpath.from(vanillaJar.path)
                 classpath.from(spigotApiDir.dir("src/main/java").path)
                 classpath.from(spigotDeps.files.filter { it.toPath().isLibraryJar })


### PR DESCRIPTION
The AccessTransformerRewriter requires bindings to resolve in order to apply ATs, which wasn't happening for some methods. Adding the remapped jar to the classpath seems to have fixed this, what I'm unsure about is why it worked without this change for many methods.