### PR TITLE
Apply ATs in userdev

### DIFF
--- a/paperweight-core/src/main/kotlin/PaperweightCore.kt
+++ b/paperweight-core/src/main/kotlin/PaperweightCore.kt
@@ -70,9 +70,9 @@ class PaperweightCore : Plugin<Project> {
             ext.serverProject,
             ext.minecraftVersion,
             tasks.downloadServerJar.map { it.outputJar.path },
-            tasks.remapJar.map { it.outputJar.path },
+            tasks.decompileJar.map { it.outputJar.path },
             tasks.inspectVanillaJar.map { it.serverLibraries.path },
-            tasks.downloadMcLibraries.map { it.outputDir.path }
+            tasks.mergeAdditionalAts.map { it.outputFile.path }
         ) {
             vanillaJarIncludes.set(ext.vanillaJarIncludes)
             reobfMappingsFile.set(tasks.patchReobfMappings.flatMap { it.outputMappings })
@@ -90,7 +90,6 @@ class PaperweightCore : Plugin<Project> {
         target.tasks.register<PaperweightCoreUpstreamData>(PAPERWEIGHT_PREPARE_DOWNSTREAM) {
             dependsOn(tasks.applyPatches)
             vanillaJar.set(tasks.downloadServerJar.flatMap { it.outputJar })
-            initialRemapJar.set(tasks.remapJar.flatMap { it.outputJar })
             remappedJar.set(tasks.copyResources.flatMap { it.outputJar })
             decompiledJar.set(tasks.decompileJar.flatMap { it.outputJar })
             mcVersion.set(target.ext.minecraftVersion)
@@ -104,6 +103,7 @@ class PaperweightCore : Plugin<Project> {
             vanillaJarIncludes.set(ext.vanillaJarIncludes)
             paramMappingsUrl.set(ext.paramMappingsRepo)
             paramMappingsConfig.set(target.configurations.named(PARAM_MAPPINGS_CONFIG))
+            atFile.set(tasks.mergeAdditionalAts.flatMap { it.outputFile })
 
             dataFile.set(
                 target.layout.file(

--- a/paperweight-core/src/main/kotlin/tasks/PaperweightCoreUpstreamData.kt
+++ b/paperweight-core/src/main/kotlin/tasks/PaperweightCoreUpstreamData.kt
@@ -49,9 +49,6 @@ abstract class PaperweightCoreUpstreamData : DefaultTask() {
     abstract val remappedJar: RegularFileProperty
 
     @get:InputFile
-    abstract val initialRemapJar: RegularFileProperty
-
-    @get:InputFile
     abstract val decompiledJar: RegularFileProperty
 
     @get:Input
@@ -94,6 +91,9 @@ abstract class PaperweightCoreUpstreamData : DefaultTask() {
     @get:Classpath
     abstract val paramMappingsConfig: Property<Configuration>
 
+    @get:InputFile
+    abstract val atFile: RegularFileProperty
+
     @TaskAction
     fun run() {
         val dataFilePath = dataFile.path
@@ -102,7 +102,6 @@ abstract class PaperweightCoreUpstreamData : DefaultTask() {
 
         val data = UpstreamData(
             vanillaJar.path,
-            initialRemapJar.path,
             remappedJar.path,
             decompiledJar.path,
             mcVersion.get(),
@@ -114,7 +113,8 @@ abstract class PaperweightCoreUpstreamData : DefaultTask() {
             sourceMappings.path,
             reobfPackagesToFix.get(),
             vanillaJarIncludes.get(),
-            determineMavenDep(paramMappingsUrl, paramMappingsConfig)
+            determineMavenDep(paramMappingsUrl, paramMappingsConfig),
+            atFile.path
         )
         dataFilePath.bufferedWriter(Charsets.UTF_8).use { writer ->
             gson.toJson(data, writer)

--- a/paperweight-lib/src/main/kotlin/tasks/GenerateDevBundle.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/GenerateDevBundle.kt
@@ -100,6 +100,9 @@ abstract class GenerateDevBundle : DefaultTask() {
     @get:InputFile
     abstract val reobfMappingsFile: RegularFileProperty
 
+    @get:InputFile
+    abstract val atFile: RegularFileProperty
+
     @get:OutputFile
     abstract val devBundleFile: RegularFileProperty
 
@@ -127,6 +130,7 @@ abstract class GenerateDevBundle : DefaultTask() {
                 dataZip.createDirectories()
                 reobfMappingsFile.path.copyTo(dataZip.resolve(reobfMappingsFileName))
                 mojangMappedPaperclipFile.path.copyTo(dataZip.resolve(mojangMappedPaperclipFileName))
+                atFile.path.copyTo(dataZip.resolve(atFileName))
 
                 val patchesZip = zip.getPath(patchesDir)
                 tempPatchDir.copyRecursivelyTo(patchesZip)
@@ -293,6 +297,7 @@ abstract class GenerateDevBundle : DefaultTask() {
         return BuildData(
             paramMappings = MavenDep(paramMappingsUrl.get(), listOf(paramMappingsCoordinates.get())),
             reobfMappingsFile = "$targetDir/$reobfMappingsFileName",
+            accessTransformFile = "$targetDir/$atFileName",
             mojangMappedPaperclipFile = "$targetDir/$mojangMappedPaperclipFileName",
             vanillaJarIncludes = vanillaJarIncludes.get(),
             libraryDependencies = determineLibraries(vanillaServerLibraries.get()),
@@ -359,6 +364,7 @@ abstract class GenerateDevBundle : DefaultTask() {
     data class BuildData(
         val paramMappings: MavenDep,
         val reobfMappingsFile: String,
+        val accessTransformFile: String,
         val mojangMappedPaperclipFile: String,
         val vanillaJarIncludes: List<String>,
         val libraryDependencies: Set<String>,
@@ -369,10 +375,11 @@ abstract class GenerateDevBundle : DefaultTask() {
     data class Runner(val dep: MavenDep, val args: List<String>)
 
     companion object {
+        const val atFileName = "transform.at"
         const val reobfMappingsFileName = "$DEOBF_NAMESPACE-$SPIGOT_NAMESPACE-reobf.tiny"
         const val mojangMappedPaperclipFileName = "paperclip-$DEOBF_NAMESPACE.jar"
 
         // Should be bumped when the dev bundle config/contents changes in a way which will require users to update paperweight
-        const val currentDataVersion = 0
+        const val currentDataVersion = 1
     }
 }

--- a/paperweight-lib/src/main/kotlin/util/UpstreamData.kt
+++ b/paperweight-lib/src/main/kotlin/util/UpstreamData.kt
@@ -28,7 +28,6 @@ import org.gradle.api.file.RegularFile
 
 data class UpstreamData(
     val vanillaJar: Path,
-    val initialRemapJar: Path,
     val remappedJar: Path,
     val decompiledJar: Path,
     val mcVersion: String,
@@ -40,7 +39,8 @@ data class UpstreamData(
     val sourceMappings: Path,
     val reobfPackagesToFix: List<String>?,
     val vanillaIncludes: List<String>,
-    val paramMappings: MavenDep
+    val paramMappings: MavenDep,
+    val accessTransform: Path
 )
 
 fun readUpstreamData(inputFile: RegularFile): UpstreamData? {

--- a/paperweight-patcher/src/main/kotlin/PaperweightPatcher.kt
+++ b/paperweight-patcher/src/main/kotlin/PaperweightPatcher.kt
@@ -137,9 +137,9 @@ class PaperweightPatcher : Plugin<Project> {
                 patcher.serverProject,
                 upstreamData.map { it.mcVersion },
                 upstreamData.map { it.vanillaJar },
-                upstreamData.map { it.initialRemapJar },
+                upstreamData.map { it.decompiledJar },
                 upstreamData.map { it.libFile ?: throw PaperweightException("No libs file?") },
-                upstreamData.map { it.libDir },
+                upstreamData.map { it.accessTransform }
             ) {
                 vanillaJarIncludes.set(upstreamData.map { it.vanillaIncludes })
                 reobfMappingsFile.set(generateReobfMappings.flatMap { it.reobfMappings })

--- a/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
@@ -194,7 +194,7 @@ abstract class PaperweightUser : Plugin<Project> {
         }
         if (!hasDevBundle) {
             val message = "paperweight requires a development bundle to be added to the 'paperweightDevelopmentBundle' configuration, as" +
-                "well as a repository to resolve it from in order to function. Use the paperweightDevBundle extension function to do this easily."
+                " well as a repository to resolve it from in order to function. Use the paperweightDevBundle extension function to do this easily."
             throw PaperweightException(message)
         }
     }


### PR DESCRIPTION
Simplifies dev bundle generation by using the standard decompileJar instead of having a separate decompile. This is accomplished by applying fixJar and ATs in userdev, which also has the benefit of fixing ATs in unmodified files for the source jar.