### PR TITLE
Use provider for final remap jar instead of path

### DIFF
--- a/paperweight-core/src/main/kotlin/PaperweightCore.kt
+++ b/paperweight-core/src/main/kotlin/PaperweightCore.kt
@@ -147,7 +147,7 @@ class PaperweightCore : Plugin<Project> {
 
             val (_, reobfJar) = serverProj.setupServerProject(
                 target,
-                cache.resolve(FINAL_REMAPPED_JAR),
+                tasks.copyResources.flatMap { it.outputJar },
                 tasks.decompileJar.flatMap { it.outputJar },
                 ext.mcDevSourceDir.path,
                 cache.resolve(SERVER_LIBRARIES),


### PR DESCRIPTION
Fixes deprecation warning about task dependencies