### PR TITLE
Revert "Update for tiny-remapper 0.4.3 changes"

### DIFF
--- a/paperweight-lib/src/main/kotlin/tasks/RemapJar.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/RemapJar.kt
@@ -42,10 +42,10 @@ val tinyRemapperArgsList: List<String> = listOf(
     "{from}",
     "{to}",
     "{classpath}",
-    "--fix-package-access",
-    "--rename-invalid-locals",
+    "--fixpackageaccess",
+    "--renameinvalidlocals",
     "--threads=1",
-    "--rebuild-source-filenames"
+    "--rebuildsourcefilenames"
 )
 
 private fun List<String>.createTinyRemapperArgs(


### PR DESCRIPTION
This reverts commit 4b329b2e8c51c7d133d83d645a6c8d6deb419edb.

Quilt now plans to simply mirror fabric instead of maintaining
their own TR fork, this allows us to switch back to upstream TR.