### PR TITLE
userdev: Set Obfuscation attribute on reobf configuration

### DIFF
--- a/paperweight-userdev/src/main/kotlin/Obfuscation.kt
+++ b/paperweight-userdev/src/main/kotlin/Obfuscation.kt
@@ -1,0 +1,50 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2021 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.userdev
+
+import org.gradle.api.Named
+import org.gradle.api.attributes.Attribute
+
+/**
+ * Attribute representing the state of obfuscation.
+ */
+interface Obfuscation : Named {
+    companion object {
+        val OBFUSCATION_ATTRIBUTE = Attribute.of(
+            "io.papermc.obfuscation",
+            Obfuscation::class.java
+        )
+
+        // Note that we don't reference this in the project, but you can use it as a value to pick the
+        // runtimeElements configuration instead of reobf.
+        /**
+         * No obfuscation, i.e. using human-readable names.
+         */
+        const val NONE = "none"
+
+        /**
+         * Obfuscated, i.e. using runtime names.
+         */
+        const val OBFUSCATED = "obfuscated"
+    }
+}

--- a/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
@@ -25,6 +25,7 @@ package io.papermc.paperweight.userdev
 import io.papermc.paperweight.DownloadService
 import io.papermc.paperweight.PaperweightException
 import io.papermc.paperweight.tasks.*
+import io.papermc.paperweight.userdev.attribute.Obfuscation
 import io.papermc.paperweight.userdev.internal.setup.UserdevSetup
 import io.papermc.paperweight.util.*
 import io.papermc.paperweight.util.constants.*

--- a/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
@@ -98,6 +98,7 @@ abstract class PaperweightUser : Plugin<Project> {
                 attribute(Category.CATEGORY_ATTRIBUTE, target.objects.named(Category.LIBRARY))
                 attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, target.objects.named(LibraryElements.JAR))
                 attribute(Bundling.BUNDLING_ATTRIBUTE, target.objects.named(Bundling.EXTERNAL))
+                attribute(Obfuscation.OBFUSCATION_ATTRIBUTE, target.objects.named(Obfuscation.OBFUSCATED))
             }
             outgoing.artifact(reobfJar)
         }

--- a/paperweight-userdev/src/main/kotlin/attribute/Obfuscation.kt
+++ b/paperweight-userdev/src/main/kotlin/attribute/Obfuscation.kt
@@ -20,7 +20,7 @@
  * USA
  */
 
-package io.papermc.paperweight.userdev
+package io.papermc.paperweight.userdev.attribute
 
 import org.gradle.api.Named
 import org.gradle.api.attributes.Attribute
@@ -31,7 +31,7 @@ import org.gradle.api.attributes.Attribute
 interface Obfuscation : Named {
     companion object {
         val OBFUSCATION_ATTRIBUTE = Attribute.of(
-            "io.papermc.obfuscation",
+            "io.papermc.paperweight.obfuscation",
             Obfuscation::class.java
         )
 


### PR DESCRIPTION
This allows selection of the reobf element separately from the runtime elements.

If you find yourself encountering something like:
```java
      > Cannot choose between the following variants of project :worldedit-bukkit:adapters:adapter-1.17:
          - reobf
          - runtimeElements
        All of them match the consumer attributes:
          - Variant 'reobf' capability com.sk89q.worldedit:adapter-1.17:7.2.7-SNAPSHOT:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.dependency.bundling 'external' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
          - Variant 'runtimeElements' capability com.sk89q.worldedit:adapter-1.17:7.2.7-SNAPSHOT:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.dependency.bundling 'external' but the consumer didn't ask for it
                  - Provides org.gradle.jvm.version '8' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
```
This will solve it by allowing you to do:
```kotlin
configurations["yourConfiguration"].apply {
    attributes {
        attribute(Obfuscation.OBFUSCATION_ATTRIBUTE, objects.named(Obfuscation.OBFUSCATED)) // or NONE
    }
}
```