### PR TITLE
Fix issue in 1.1.12 that causes task remapJar to crash when run

### DIFF
--- a/paperweight-lib/src/main/kotlin/tasks/RemapJar.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/RemapJar.kt
@@ -42,10 +42,10 @@ val tinyRemapperArgsList: List<String> = listOf(
     "{from}",
     "{to}",
     "{classpath}",
-    "--fixpackageaccess",
-    "--renameinvalidlocals",
+    "--fix-package-access",
+    "--rename-invalid-locals",
     "--threads=1",
-    "--rebuildsourcefilenames"
+    "--rebuild-source-filenames"
 )
 
 private fun List<String>.createTinyRemapperArgs(


### PR DESCRIPTION
Small patch which fixes an issue that causes RemapJar to crash when run.

This only seems to affect 1.1.12-SNAPSHOT, as extensive testing with 1.1.11 fails to reproduce the issue.

The full log of the crash is as follows:
```
* What went wrong:
Execution failed for task ':paper:remapJar'.
> io.papermc.paperweight.PaperweightException: Execution of C:\Users\vertig0\.gradle\caches\modules-2\files-2.1\org.quiltmc\tiny-remapper\0.4.3\9491acab4383a9443b1bff934031ddd67b2caf4e\tiny-remapper-0.4.3-fat.jar;C:\Users\vertig0\.gradle\caches\modules-2\files-2.1\org.ow2.asm\asm-commons\9.1\8b971b182eb5cf100b9e8d4119152d83e00e0fdd\asm-commons-9.1.jar;C:\Users\vertig0\.gradle\caches\modules-2\files-2.1\org.ow2.asm\asm-util\9.1\36464a45d871779f3383a8a9aba2b26562a86729\asm-util-9.1.jar;C:\Users\vertig0\.gradle\caches\modules-2\files-2.1\org.ow2.asm\asm-analysis\9.1\4f61b83b81d8b659958f4bcc48907e93ecea55a0\asm-analysis-9.1.jar;C:\Users\vertig0\.gradle\caches\modules-2\files-2.1\org.ow2.asm\asm-tree\9.1\c333f2a855069cb8eb17a40a3eb8b1b67755d0eb\asm-tree-9.1.jar;C:\Users\vertig0\.gradle\caches\modules-2\files-2.1\org.ow2.asm\asm\9.1\a99500cf6eea30535eeac6be73899d048f8d12a8\asm-9.1.jar;C:\Users\vertig0\.gradle\caches\modules-2\files-2.1\info.picocli\picocli\4.6.1\49a67ee4b4d9722fa60f3f9ffaffa72861c32966\picocli-4.6.1.jar;C:\Users\vertig0\.gradle\caches\modules-2\files-2.1\info.picocli\picocli-jansi-graalvm\1.2.0\bd6c8f86f71f9bea3253098bde228e8aa94f1829\picocli-jansi-graalvm-1.2.0.jar;C:\Users\vertig0\.gradle\caches\modules-2\files-2.1\org.fusesource.jansi\jansi\2.3.3\64fda85e12788a194f374fd49e8f197b29c4f176\jansi-2.3.3.jar failed with exit code 2
```

(Was discovered by fluke when my fork's injector forced the upstream project to use version 1.1.12, force injecting any other version as mentioned does not result in the issue)