### PR TITLE
Init submodules in clone task for paper upstreams

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = io.papermc.paperweight
-version = 1.1.12
+version = 1.1.13-SNAPSHOT

--- a/paperweight-patcher/src/main/kotlin/upstream/patchers.kt
+++ b/paperweight-patcher/src/main/kotlin/upstream/patchers.kt
@@ -89,6 +89,10 @@ open class DefaultPaperRepoPatcherUpstream(name: String, objects: ObjectFactory,
             serverOutputDir.convention(minimalConfig.serverOutputDir)
         }
 
+        cloneTask {
+            initializeSubmodules.convention(true)
+        }
+
         withStandardPatcher(paperAction)
     }
 }


### PR DESCRIPTION
Gradle seems to like it more when we init/update the submodules before starting the build. I noticed it was telling me inputs were changing/up to date when they shouldn't be when the submodules are updated during the build.

`applyPatches` time results on my machine with a clean clone of a fork of a fork of Paper, and an empty build cache.

<table>
<tr>
	<td>
	<td>Without this PR
	<td>With this PR
<tr>
	<td>Build 1
	<td>~3min10s
	<td>~3min10s
<tr>
	<td>Build 2
	<td>~1min45s
	<td>~10s
<tr>
	<td>Build 3
	<td>~10s
	<td>~6s
</table>