### PR TITLE
Init submodules in clone tasks by default

### DIFF
--- a/paperweight-patcher/src/main/kotlin/tasks/CheckoutRepo.kt
+++ b/paperweight-patcher/src/main/kotlin/tasks/CheckoutRepo.kt
@@ -67,7 +67,7 @@ abstract class CheckoutRepo : DefaultTask() {
             url.finalizeValueOnRead()
             ref.finalizeValueOnRead()
             shallowClone.convention(true).finalizeValueOnRead()
-            initializeSubmodules.convention(false).finalizeValueOnRead()
+            initializeSubmodules.convention(true).finalizeValueOnRead()
             initializeSubmodulesShallow.convention(false).finalizeValueOnRead()
 
             outputDir.convention(workDir.dir(repoName)).finalizeValueOnRead()

--- a/paperweight-patcher/src/main/kotlin/upstream/patchers.kt
+++ b/paperweight-patcher/src/main/kotlin/upstream/patchers.kt
@@ -89,10 +89,6 @@ open class DefaultPaperRepoPatcherUpstream(name: String, objects: ObjectFactory,
             serverOutputDir.convention(minimalConfig.serverOutputDir)
         }
 
-        cloneTask {
-            initializeSubmodules.convention(true)
-        }
-
         withStandardPatcher(paperAction)
     }
 }


### PR DESCRIPTION
Didn't think of this until after #92 was merged, but there isn't really any harm in running init submodules when there aren't submodules, and it's possible someone with an upstream using submodules could forget to set this, so it seems better to just enable it by default.