### PR TITLE
Use server libraries from inspectVanillaJar for userdev + sources downloads

### DIFF
--- a/paperweight-core/src/main/kotlin/PaperweightCore.kt
+++ b/paperweight-core/src/main/kotlin/PaperweightCore.kt
@@ -95,7 +95,7 @@ class PaperweightCore : Plugin<Project> {
             mcVersion.set(target.ext.minecraftVersion)
             mcLibrariesFile.set(tasks.inspectVanillaJar.flatMap { it.serverLibraries })
             mcLibrariesDir.set(tasks.downloadMcLibraries.flatMap { it.outputDir })
-            mcLibrariesSourcesDir.set(tasks.downloadMcLibraries.flatMap { it.sourcesOutputDir })
+            mcLibrariesSourcesDir.set(tasks.downloadMcLibrariesSources.flatMap { it.outputDir })
             mappings.set(tasks.patchMappings.flatMap { it.outputMappings })
             notchToSpigotMappings.set(tasks.generateSpigotMappings.flatMap { it.notchToSpigotMappings })
             sourceMappings.set(tasks.generateMappings.flatMap { it.outputMappings })
@@ -201,7 +201,7 @@ class PaperweightCore : Plugin<Project> {
             spigotDecompJar.set(allTasks.spigotDecompileJar.flatMap { it.outputJar }.get())
 
             // library class imports
-            mcLibrarySourcesDir.set(allTasks.downloadMcLibraries.flatMap { it.sourcesOutputDir }.get())
+            mcLibrarySourcesDir.set(allTasks.downloadMcLibrariesSources.flatMap { it.outputDir }.get())
             devImports.set(extension.paper.devImports)
 
             outputPatchDir.set(extension.paper.remappedSpigotServerPatchDir)

--- a/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
@@ -102,7 +102,7 @@ open class AllTasks(
         caseOnlyClassNameChanges.set(cleanupMappings.flatMap { it.caseOnlyNameChanges })
         upstreamDir.set(patchSpigotServer.flatMap { it.outputDir })
         sourceMcDevJar.set(decompileJar.flatMap { it.outputJar })
-        mcLibrariesDir.set(downloadMcLibraries.flatMap { it.sourcesOutputDir })
+        mcLibrariesDir.set(downloadMcLibrariesSources.flatMap { it.outputDir })
         devImports.set(extension.paper.devImports.fileExists(project))
         unneededFiles.value(listOf("nms-patches", "applyPatches.sh", "CONTRIBUTING.md", "makePatches.sh", "README.md"))
 

--- a/paperweight-core/src/main/kotlin/taskcontainers/SpigotTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/SpigotTasks.kt
@@ -52,14 +52,6 @@ open class SpigotTasks(
         additionalMemberEntriesSrg.set(extension.paper.additionalSpigotMemberMappings.fileExists(project))
     }
 
-    val inspectVanillaJar by tasks.registering<InspectVanillaJar> {
-        inputJar.set(downloadServerJar.flatMap { it.outputJar })
-        libraries.from(downloadMcLibraries.map { it.outputDir.asFileTree })
-        mcLibraries.set(setupMcLibraries.flatMap { it.outputFile })
-
-        serverLibraries.set(cache.resolve(SERVER_LIBRARIES))
-    }
-
     val generateSpigotMappings by tasks.registering<GenerateSpigotMappings> {
         classMappings.set(addAdditionalSpigotMappings.flatMap { it.outputClassSrg })
         memberMappings.set(addAdditionalSpigotMappings.flatMap { it.outputMemberSrg })

--- a/paperweight-core/src/main/kotlin/taskcontainers/VanillaTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/VanillaTasks.kt
@@ -44,7 +44,23 @@ open class VanillaTasks(
         mcLibrariesFile.set(setupMcLibraries.flatMap { it.outputFile })
         mcRepo.set(MC_LIBRARY_URL)
         outputDir.set(cache.resolve(MINECRAFT_JARS_PATH))
-        sourcesOutputDir.set(cache.resolve(MINECRAFT_SOURCES_PATH))
+
+        downloader.set(downloadService)
+    }
+
+    val inspectVanillaJar by tasks.registering<InspectVanillaJar> {
+        inputJar.set(downloadServerJar.flatMap { it.outputJar })
+        libraries.from(downloadMcLibraries.map { it.outputDir.asFileTree })
+        mcLibraries.set(setupMcLibraries.flatMap { it.outputFile })
+
+        serverLibraries.set(cache.resolve(SERVER_LIBRARIES))
+    }
+
+    val downloadMcLibrariesSources by tasks.registering<DownloadMcLibraries> {
+        mcLibrariesFile.set(inspectVanillaJar.flatMap { it.serverLibraries })
+        mcRepo.set(MC_LIBRARY_URL)
+        outputDir.set(cache.resolve(MINECRAFT_SOURCES_PATH))
+        sources.set(true)
 
         downloader.set(downloadService)
     }

--- a/paperweight-lib/src/main/kotlin/tasks/GenerateDevBundle.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/GenerateDevBundle.kt
@@ -300,6 +300,7 @@ abstract class GenerateDevBundle : DefaultTask() {
             accessTransformFile = "$targetDir/$atFileName",
             mojangMappedPaperclipFile = "$targetDir/$mojangMappedPaperclipFileName",
             vanillaJarIncludes = vanillaJarIncludes.get(),
+            vanillaServerLibraries = vanillaServerLibraries.get(),
             libraryDependencies = determineLibraries(vanillaServerLibraries.get()),
             libraryRepositories = libraryRepositories.get(),
             relocations = relocations()
@@ -367,6 +368,7 @@ abstract class GenerateDevBundle : DefaultTask() {
         val accessTransformFile: String,
         val mojangMappedPaperclipFile: String,
         val vanillaJarIncludes: List<String>,
+        val vanillaServerLibraries: List<String>,
         val libraryDependencies: Set<String>,
         val libraryRepositories: List<String>,
         val relocations: List<Relocation>


### PR DESCRIPTION
Avoids downloading client libraries in userdev, and avoids downloading sources for client libraries in core/patcher