### PR TITLE
Fix reobf for synthetic `this$` fields on non-static inner classes which spigot recompiles

### DIFF
--- a/paperweight-core/src/main/kotlin/PaperweightCore.kt
+++ b/paperweight-core/src/main/kotlin/PaperweightCore.kt
@@ -104,6 +104,7 @@ class PaperweightCore : Plugin<Project> {
             paramMappingsUrl.set(ext.paramMappingsRepo)
             paramMappingsConfig.set(target.configurations.named(PARAM_MAPPINGS_CONFIG))
             atFile.set(tasks.mergeAdditionalAts.flatMap { it.outputFile })
+            spigotRecompiledClasses.set(tasks.remapSpigotSources.flatMap { it.spigotRecompiledClasses })
 
             dataFile.set(
                 target.layout.file(

--- a/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
@@ -145,6 +145,7 @@ open class AllTasks(
         inputMappings.set(patchMappings.flatMap { it.outputMappings })
         notchToSpigotMappings.set(generateSpigotMappings.flatMap { it.notchToSpigotMappings })
         sourceMappings.set(generateMappings.flatMap { it.outputMappings })
+        spigotRecompiledClasses.set(remapSpigotSources.flatMap { it.spigotRecompiledClasses })
 
         reobfMappings.set(cache.resolve(REOBF_MOJANG_SPIGOT_MAPPINGS))
     }

--- a/paperweight-core/src/main/kotlin/tasks/PaperweightCorePrepareForDownstream.kt
+++ b/paperweight-core/src/main/kotlin/tasks/PaperweightCorePrepareForDownstream.kt
@@ -95,6 +95,9 @@ abstract class PaperweightCorePrepareForDownstream : DefaultTask() {
     @get:InputFile
     abstract val atFile: RegularFileProperty
 
+    @get:InputFile
+    abstract val spigotRecompiledClasses: RegularFileProperty
+
     @TaskAction
     fun run() {
         val dataFilePath = dataFile.path
@@ -116,7 +119,8 @@ abstract class PaperweightCorePrepareForDownstream : DefaultTask() {
             reobfMappingsPatch.path,
             vanillaJarIncludes.get(),
             determineMavenDep(paramMappingsUrl, paramMappingsConfig),
-            atFile.path
+            atFile.path,
+            spigotRecompiledClasses.path,
         )
         dataFilePath.bufferedWriter(Charsets.UTF_8).use { writer ->
             gson.toJson(data, writer)

--- a/paperweight-lib/src/main/kotlin/util/UpstreamData.kt
+++ b/paperweight-lib/src/main/kotlin/util/UpstreamData.kt
@@ -41,7 +41,8 @@ data class UpstreamData(
     val reobfMappingsPatch: Path,
     val vanillaIncludes: List<String>,
     val paramMappings: MavenDep,
-    val accessTransform: Path
+    val accessTransform: Path,
+    val spigotRecompiledClasses: Path,
 )
 
 fun readUpstreamData(inputFile: Any): UpstreamData = inputFile.convertToPath().let { file ->

--- a/paperweight-patcher/src/main/kotlin/PaperweightPatcher.kt
+++ b/paperweight-patcher/src/main/kotlin/PaperweightPatcher.kt
@@ -160,6 +160,7 @@ class PaperweightPatcher : Plugin<Project> {
                 notchToSpigotMappings.pathProvider(upstreamData.map { it.notchToSpigotMappings })
                 sourceMappings.pathProvider(upstreamData.map { it.sourceMappings })
                 inputJar.set(serverProj.tasks.named("shadowJar", Jar::class).flatMap { it.archiveFile })
+                spigotRecompiledClasses.pathProvider(upstreamData.map { it.spigotRecompiledClasses })
 
                 reobfMappings.set(target.layout.cache.resolve(REOBF_MOJANG_SPIGOT_MAPPINGS))
             }


### PR DESCRIPTION
In classes which spigot doesn't recompile, synthetic `this$` fields are left as obfuscated by ProGuard, but for recompiled classes, they are left "unobfuscated" as generated by the compiler from recompiling the decompiled source. We were previously reobfuscating all `this$` fields when we should not be reobfuscating the ones in classes recompiled by spigot, to more closely match their final jar. 