### PR TITLE
Change patcher's shadowJar to use server task

### DIFF
--- a/paperweight-patcher/src/main/kotlin/PaperweightPatcher.kt
+++ b/paperweight-patcher/src/main/kotlin/PaperweightPatcher.kt
@@ -157,12 +157,13 @@ class PaperweightPatcher : Plugin<Project> {
 
             val serverProj = patcher.serverProject.forUseAtConfigurationTime().orNull ?: return@afterEvaluate
             serverProj.apply(plugin = "com.github.johnrengelman.shadow")
+            val shadowJar = serverProj.tasks.named("shadowJar", Jar::class)
 
             generateReobfMappings {
                 inputMappings.pathProvider(upstreamData.map { it.mappings })
                 notchToSpigotMappings.pathProvider(upstreamData.map { it.notchToSpigotMappings })
                 sourceMappings.pathProvider(upstreamData.map { it.sourceMappings })
-                inputJar.set(serverProj.tasks.named("shadowJar", Jar::class).flatMap { it.archiveFile })
+                inputJar.set(shadowJar.flatMap { it.archiveFile })
                 spigotRecompiledClasses.pathProvider(upstreamData.map { it.spigotRecompiledClasses })
 
                 reobfMappings.set(target.layout.cache.resolve(REOBF_MOJANG_SPIGOT_MAPPINGS))
@@ -203,7 +204,7 @@ class PaperweightPatcher : Plugin<Project> {
                 upstreamData.map { it.serverLibrariesList }.convertToFileProvider(target.layout, target.providers),
                 upstreamData.map { it.vanillaJar }.convertToFileProvider(target.layout, target.providers),
                 serverProj,
-                tasks.named("shadowJar", Jar::class),
+                shadowJar,
                 reobfJar,
                 upstreamData.map { it.mcVersion }
             )


### PR DESCRIPTION
Previously the patcher would attempt to use the root projects shadowJar
output when compiling its reobfuscated output which obviously fails as
the root project does not have an applied shadow task.

This commit fixes this by using the shadowJar output of the server
implementation.