### PR TITLE
Pass bundler instead of server jar to patcher

### DIFF
--- a/paperweight-core/src/main/kotlin/PaperweightCore.kt
+++ b/paperweight-core/src/main/kotlin/PaperweightCore.kt
@@ -87,7 +87,7 @@ class PaperweightCore : Plugin<Project> {
 
         target.tasks.register<PaperweightCorePrepareForDownstream>(PAPERWEIGHT_PREPARE_DOWNSTREAM) {
             dependsOn(tasks.applyPatches)
-            vanillaJar.set(tasks.extractFromBundler.flatMap { it.serverJar })
+            vanillaJar.set(tasks.extractFromBundler.flatMap { it.bundlerJar })
             remappedJar.set(tasks.copyResources.flatMap { it.outputJar })
             decompiledJar.set(tasks.decompileJar.flatMap { it.outputJar })
             mcVersion.set(target.ext.minecraftVersion)


### PR DESCRIPTION
Previously the upstream data would point the vanilla jar to the
server.jar the bundler generates. The server jar however does not
contain the metadata required, such as as 'META-INF/versions.list' and
instead only contains the server classes.

This commit changes that behaviour to now pass the bundler jar instead
of the server jar to the upstream data, allowing the patcher to properly
create bundlers.

---------------------------------------------------------------------------------------------------

Generally, I am unsure if this should just straight out replace the `vanillaJar` or if we should add a `vanillaBundlerJar` field to the upstream data file, to properly pass both. Feedback on this would be appreciated!