### PR TITLE
A more convenient Gitlab support in paperweight-patcher upstream

### DIFF
--- a/paperweight-patcher/src/main/kotlin/upstream/RepoPatcherUpstream.kt
+++ b/paperweight-patcher/src/main/kotlin/upstream/RepoPatcherUpstream.kt
@@ -39,5 +39,9 @@ interface RepoPatcherUpstream : PatcherUpstream {
         return "https://github.com/$owner/$repo.git"
     }
 
+    fun gitlab(owner: String, repo: String): String {
+        return "https://gitlab.com/$owner/$repo.git"
+    }
+
     fun withStandardPatcher(action: Action<StandardPatcherConfig>)
 }


### PR DESCRIPTION
In case some people need to fork repos from Gitlab.