### PR TITLE
Run git prune after applying patches

### DIFF
--- a/paperweight-lib/src/main/kotlin/tasks/ApplyGitPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ApplyGitPatches.kt
@@ -168,6 +168,7 @@ fun ControllableOutputTask.applyGitPatches(
             }
         }
     } finally {
+        git("prune").run() // cleanup old git objects
         tempDir.deleteRecursively()
     }
 }


### PR DESCRIPTION
After changing branches, applying patches, changing to other branches, this seems to prevent the frequent message that instructs users to run `git prune` and then delete `.git/gc.log`.

Can add if needed, the deletion of the .git/gc.log file, as that's what actually stops the warning message from being shown