### PR TITLE
Copy the flightrecorder config as a resource

### DIFF
--- a/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
@@ -57,7 +57,7 @@ open class AllTasks(
     val copyResources by tasks.registering<CopyResources> {
         inputJar.set(applyMergedAt.flatMap { it.outputJar })
         vanillaJar.set(extractFromBundler.flatMap { it.serverJar })
-        includes.set(listOf("/data/**", "/assets/**", "version.json", "yggdrasil_session_pubkey.der", "pack.mcmeta"))
+        includes.set(listOf("/data/**", "/assets/**", "version.json", "yggdrasil_session_pubkey.der", "pack.mcmeta", "flightrecorder-config.jfc"))
 
         outputJar.set(cache.resolve(FINAL_REMAPPED_JAR))
     }


### PR DESCRIPTION
Paperweight actively defines an includes list for any resource that are
copied over from the vanilla (remapped) server jar.

Minecraft 1.18 added the /jfr command, allowing users and server
administrators to use java's flight recorder to analyse and collect
data about their clients/servers runtime.
For this a 'flightrecorder-config.jfc' configuration file was added.

This commit now properly includes the file in the includes list of the
copy resources tasks, hence including the configuration file in compiled
paper servers which re-enables the previously failing /jfr command.

Resolves: PaperMC/Paper#7566