### PR TITLE
Switch from in- to excludes for resource inclusion

### DIFF
--- a/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
@@ -57,7 +57,7 @@ open class AllTasks(
     val copyResources by tasks.registering<CopyResources> {
         inputJar.set(applyMergedAt.flatMap { it.outputJar })
         vanillaJar.set(extractFromBundler.flatMap { it.serverJar })
-        includes.set(listOf("/data/**", "/assets/**", "version.json", "yggdrasil_session_pubkey.der", "pack.mcmeta", "flightrecorder-config.jfc"))
+        excludes.convention(listOf("**/*.class", "/META-INF/**"))
 
         outputJar.set(cache.resolve(FINAL_REMAPPED_JAR))
     }

--- a/paperweight-lib/src/main/kotlin/tasks/CopyResources.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/CopyResources.kt
@@ -42,7 +42,7 @@ abstract class CopyResources : BaseTask() {
     abstract val vanillaJar: RegularFileProperty
 
     @get:Input
-    abstract val includes: ListProperty<String>
+    abstract val excludes: ListProperty<String>
 
     @get:OutputFile
     abstract val outputJar: RegularFileProperty
@@ -55,8 +55,8 @@ abstract class CopyResources : BaseTask() {
 
         fs.copy {
             from(archives.zipTree(vanillaJar)) {
-                for (inc in this@CopyResources.includes.get()) {
-                    include(inc)
+                for (inc in this@CopyResources.excludes.get()) {
+                    exclude(inc)
                 }
             }
             from(archives.zipTree(inputJar))


### PR DESCRIPTION
As nearly all resources found in the vanilla jar are desired to be
included in paper, an include list is not ideal. Instead, this commit
changes the copy resource tasks to an exclude-based filter.