### PR TITLE
Support including project dependencies in the dev bundle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = io.papermc.paperweight
-version = 1.3.9-SNAPSHOT
+version = 1.4.0-SNAPSHOT
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/paperweight-core/src/main/kotlin/PaperweightCore.kt
+++ b/paperweight-core/src/main/kotlin/PaperweightCore.kt
@@ -162,7 +162,8 @@ class PaperweightCore : Plugin<Project> {
                 tasks.extractFromBundler.map { it.serverLibrariesList.path },
                 tasks.downloadServerJar.map { it.outputJar.path },
                 tasks.mergeAdditionalAts.map { it.outputFile.path },
-                tasks.extractFromBundler.map { it.versionJson.path }.convertToFileProvider(layout, providers)
+                tasks.extractFromBundler.map { it.versionJson.path }.convertToFileProvider(layout, providers),
+                ext.devBundle,
             ) {
                 vanillaJarIncludes.set(ext.vanillaJarIncludes)
                 reobfMappingsFile.set(tasks.patchReobfMappings.flatMap { it.outputMappings })

--- a/paperweight-core/src/main/kotlin/extension/PaperweightCoreExtension.kt
+++ b/paperweight-core/src/main/kotlin/extension/PaperweightCoreExtension.kt
@@ -22,6 +22,7 @@
 
 package io.papermc.paperweight.core.extension
 
+import io.papermc.paperweight.extension.DevBundleExtension
 import io.papermc.paperweight.util.*
 import io.papermc.paperweight.util.constants.*
 import java.util.Locale
@@ -73,5 +74,13 @@ open class PaperweightCoreExtension(project: Project, objects: ObjectFactory, la
     @Suppress("unused")
     fun paper(action: Action<in PaperExtension>) {
         action.execute(paper)
+    }
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    val devBundle = DevBundleExtension(project, objects)
+
+    @Suppress("unused")
+    fun devBundle(action: Action<in DevBundleExtension>) {
+        action.execute(devBundle)
     }
 }

--- a/paperweight-lib/src/main/kotlin/extension/DevBundleExtension.kt
+++ b/paperweight-lib/src/main/kotlin/extension/DevBundleExtension.kt
@@ -1,0 +1,56 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2021 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.extension
+
+import io.papermc.paperweight.tasks.*
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.kotlin.dsl.*
+
+@Suppress("unused")
+class DevBundleExtension(
+    private val rootProject: Project,
+    objects: ObjectFactory
+) {
+    val libraryRepositories: ListProperty<String> = objects.listProperty()
+
+    /**
+     * Registers a project dependency to have its publication included in the dev bundle, and it's coordinates
+     * depended on by the server artifact. Paper registers `paper-api` and `paper-mojangapi` using this method.
+     */
+    fun registerProjectPublication(project: Project, publicationName: String, coordinates: String) {
+        rootProject.registerProjectPublicationForDevBundle(project, publicationName, coordinates)
+    }
+
+    private fun Project.registerProjectPublicationForDevBundle(
+        project: Project,
+        publicationName: String,
+        coordinates: String,
+    ) {
+        val archive = project.archivePublication(publicationName)
+        tasks.named<GenerateDevBundle>("generateDevelopmentBundle") {
+            projectArchivedPublication(project, archive, coordinates)
+        }
+    }
+}

--- a/paperweight-lib/src/main/kotlin/taskcontainers/DevBundleTasks.kt
+++ b/paperweight-lib/src/main/kotlin/taskcontainers/DevBundleTasks.kt
@@ -22,6 +22,7 @@
 
 package io.papermc.paperweight.taskcontainers
 
+import io.papermc.paperweight.extension.DevBundleExtension
 import io.papermc.paperweight.extension.RelocationExtension
 import io.papermc.paperweight.taskcontainers.BundlerJarTasks.Companion.registerVersionArtifact
 import io.papermc.paperweight.tasks.*
@@ -72,6 +73,7 @@ class DevBundleTasks(
         vanillaBundlerJarFile: Provider<Path?>,
         accessTransformFile: Provider<Path?>,
         versionJsonFile: Provider<RegularFile>,
+        devBundleExtension: DevBundleExtension,
         devBundleConfiguration: GenerateDevBundle.() -> Unit
     ) {
         serverBundlerForDevBundle {
@@ -110,6 +112,8 @@ class DevBundleTasks(
             decompiledJar.pathProvider(decompileJar)
             atFile.pathProvider(accessTransformFile)
 
+            libraryRepositories.addAll(devBundleExtension.libraryRepositories)
+
             devBundleConfiguration(this)
         }
     }
@@ -119,20 +123,5 @@ class DevBundleTasks(
             remapperUrl.set(project.repositories.named<MavenArtifactRepository>(REMAPPER_REPO_NAME).map { it.url.toString() })
             decompilerUrl.set(project.repositories.named<MavenArtifactRepository>(DECOMPILER_REPO_NAME).map { it.url.toString() })
         }
-    }
-}
-
-/**
- * Registers a project dependency to have its publication included in the dev bundle, and it's coordinates
- * depended on by the server artifact. Paper registers `paper-api` and `paper-mojangapi` using this method.
- */
-fun Project.registerProjectPublicationForDevBundle(
-    project: Project,
-    publicationName: String,
-    coordinates: String,
-) {
-    val archive = project.archivePublication(publicationName)
-    tasks.named<GenerateDevBundle>("generateDevelopmentBundle") {
-        projectArchivedPublication(project, archive, coordinates)
     }
 }

--- a/paperweight-lib/src/main/kotlin/taskcontainers/DevBundleTasks.kt
+++ b/paperweight-lib/src/main/kotlin/taskcontainers/DevBundleTasks.kt
@@ -122,3 +122,18 @@ class DevBundleTasks(
         }
     }
 }
+
+/**
+ * Registers a project dependency to have its publication included in the dev bundle, and it's coordinates
+ * depended on by the server artifact. Paper registers `paper-api` and `paper-mojangapi` using this method.
+ */
+fun Project.registerProjectPublicationForDevBundle(
+    project: Project,
+    publicationName: String,
+    coordinates: String,
+) {
+    val archive = project.archivePublication(publicationName)
+    tasks.named<GenerateDevBundle>("generateDevelopmentBundle") {
+        projectArchivedPublication(project, archive, coordinates)
+    }
+}

--- a/paperweight-lib/src/main/kotlin/taskcontainers/DevBundleTasks.kt
+++ b/paperweight-lib/src/main/kotlin/taskcontainers/DevBundleTasks.kt
@@ -102,7 +102,6 @@ class DevBundleTasks(
                 }
             )
 
-            serverVersion.set(serverProj.version.toString())
             serverCoordinates.set(GenerateDevBundle.createCoordinatesFor(serverProj))
             serverProject.set(serverProj)
             runtimeConfiguration.set(serverProj.configurations.named(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME))

--- a/paperweight-lib/src/main/kotlin/tasks/ArchivePublication.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ArchivePublication.kt
@@ -45,8 +45,8 @@ abstract class ArchivePublication : ZippedTask() {
 }
 
 fun Project.archivePublication(publicationName: String): TaskProvider<ArchivePublication> {
-    val repoName = "archiveTempRepo_$publicationName"
-    val repoDir = layout.buildDirectory.dir(repoName)
+    val repoName = "archive${publicationName.capitalize()}PublicationTempRepo"
+    val repoDir = layout.buildDirectory.dir("tmp/$repoName")
     the<PublishingExtension>().repositories {
         maven {
             name = repoName

--- a/paperweight-lib/src/main/kotlin/tasks/ArchivePublication.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/ArchivePublication.kt
@@ -1,0 +1,72 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2021 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.tasks
+
+import io.papermc.paperweight.util.*
+import java.nio.file.Path
+import kotlin.io.path.*
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.*
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(because = "Not worth caching")
+abstract class ArchivePublication : ZippedTask() {
+    @get:InputDirectory
+    abstract val repo: DirectoryProperty
+
+    override fun run(rootDir: Path) {
+        repo.path.copyRecursivelyTo(rootDir)
+    }
+}
+
+fun Project.archivePublication(publicationName: String): TaskProvider<ArchivePublication> {
+    val repoName = "archiveTempRepo_$publicationName"
+    val repoDir = layout.buildDirectory.dir(repoName)
+    the<PublishingExtension>().repositories {
+        maven {
+            name = repoName
+            setUrl(repoDir)
+        }
+    }
+    val cleanTask = tasks.register<Delete>("clean${repoName.capitalize()}") {
+        delete(repoDir)
+        doLast {
+            repoDir.get().path.createDirectories()
+        }
+    }
+    val archiveTask = tasks.register<ArchivePublication>("archive${publicationName.capitalize()}Publication") {
+        repo.set(repoDir)
+    }
+    tasks.all {
+        if (name == "publish${publicationName.capitalize()}PublicationTo${repoName.capitalize()}Repository") {
+            dependsOn(cleanTask)
+            archiveTask.get().dependsOn(this)
+        }
+    }
+    return archiveTask
+}

--- a/paperweight-lib/src/main/kotlin/tasks/CreateBundlerJar.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/CreateBundlerJar.kt
@@ -59,7 +59,7 @@ abstract class CreateBundlerJar : ZippedTask() {
     abstract val mainClass: Property<String>
 
     @get:Nested
-    val versionArtifacts: NamedDomainObjectContainer<VersionArtifact> = createVersionArtifactContainer()
+    val versionArtifacts: NamedDomainObjectContainer<VersionArtifact> = createNamedDomainObjectContainer()
 
     @get:Classpath
     @get:Optional
@@ -75,8 +75,8 @@ abstract class CreateBundlerJar : ZippedTask() {
     @get:OutputFile
     abstract val libraryChangesJson: RegularFileProperty
 
-    private fun createVersionArtifactContainer(): NamedDomainObjectContainer<VersionArtifact> =
-        objects.domainObjectContainer(VersionArtifact::class) { objects.newInstance(it) }
+    private inline fun <reified T : Any> createNamedDomainObjectContainer(): NamedDomainObjectContainer<T> =
+        objects.domainObjectContainer(T::class.java) { objects.newInstance(it) }
 
     override fun init() {
         super.init()

--- a/paperweight-lib/src/main/kotlin/tasks/GenerateDevBundle.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/GenerateDevBundle.kt
@@ -69,9 +69,6 @@ abstract class GenerateDevBundle : BaseTask() {
     abstract val mojangMappedPaperclipFile: RegularFileProperty
 
     @get:Input
-    abstract val serverVersion: Property<String>
-
-    @get:Input
     abstract val serverCoordinates: Property<String>
 
     @get:Input

--- a/paperweight-lib/src/main/kotlin/util/constants/constants.kt
+++ b/paperweight-lib/src/main/kotlin/util/constants/constants.kt
@@ -96,6 +96,7 @@ const val FINAL_DECOMPILE_JAR = "$TASK_CACHE/decompileJar.jar"
 const val MC_DEV_SOURCES_DIR = "$PAPER_PATH/mc-dev-sources"
 
 const val IVY_REPOSITORY = "$PAPER_PATH/ivyRepository"
+const val MAVEN_REPOSITORY = "$PAPER_PATH/mavenRepository"
 
 const val RELOCATION_EXTENSION = "relocation"
 

--- a/paperweight-patcher/src/main/kotlin/PaperweightPatcher.kt
+++ b/paperweight-patcher/src/main/kotlin/PaperweightPatcher.kt
@@ -179,7 +179,8 @@ class PaperweightPatcher : Plugin<Project> {
                 upstreamData.map { it.serverLibrariesList },
                 upstreamData.map { it.vanillaJar },
                 upstreamData.map { it.accessTransform },
-                upstreamData.map { it.bundlerVersionJson }.convertToFileProvider(layout, providers)
+                upstreamData.map { it.bundlerVersionJson }.convertToFileProvider(layout, providers),
+                patcher.devBundle,
             ) {
                 vanillaJarIncludes.set(upstreamData.map { it.vanillaIncludes })
                 reobfMappingsFile.set(patchReobfMappings.flatMap { it.outputMappings })

--- a/paperweight-patcher/src/main/kotlin/PaperweightPatcherExtension.kt
+++ b/paperweight-patcher/src/main/kotlin/PaperweightPatcherExtension.kt
@@ -22,6 +22,7 @@
 
 package io.papermc.paperweight.patcher
 
+import io.papermc.paperweight.extension.DevBundleExtension
 import io.papermc.paperweight.patcher.upstream.DefaultPaperRepoPatcherUpstream
 import io.papermc.paperweight.patcher.upstream.DefaultPatcherUpstream
 import io.papermc.paperweight.patcher.upstream.DefaultRepoPatcherUpstream
@@ -65,6 +66,8 @@ open class PaperweightPatcherExtension(project: Project, private val objects: Ob
 
     val upstreams: ExtensiblePolymorphicDomainObjectContainer<PatcherUpstream> = objects.polymorphicDomainObjectContainer(PatcherUpstream::class)
 
+    val devBundle = DevBundleExtension(project, objects)
+
     /**
      * The directory upstreams should be checked out in. Paperweight will use the directory specified in the
      * following order, whichever is set first:
@@ -100,5 +103,9 @@ open class PaperweightPatcherExtension(project: Project, private val objects: Ob
                 action.execute(this)
             }
         }
+    }
+
+    fun devBundle(action: Action<in DevBundleExtension>) {
+        action.execute(devBundle)
     }
 }

--- a/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
@@ -170,6 +170,8 @@ abstract class PaperweightUser : Plugin<Project> {
     }
 
     private fun Project.configureRepositories(userdevSetup: UserdevSetup) = repositories {
+        userdevSetup.addLocalRepositories(project)
+
         maven(userdevSetup.paramMappings.url) {
             name = PARAM_MAPPINGS_REPO_NAME
             content { onlyForConfigurations(PARAM_MAPPINGS_CONFIG) }
@@ -185,8 +187,6 @@ abstract class PaperweightUser : Plugin<Project> {
         for (repo in userdevSetup.libraryRepositories) {
             maven(repo)
         }
-
-        userdevSetup.addIvyRepository(project)
     }
 
     private fun Project.checkForDevBundle() {
@@ -237,7 +237,7 @@ abstract class PaperweightUser : Plugin<Project> {
             defaultDependencies {
                 val ctx = createContext(target)
                 userdevSetup.get().let { setup ->
-                    setup.createOrUpdateIvyRepository(ctx)
+                    setup.createOrUpdateLocalRepositories(ctx)
                     setup.populateCompileConfiguration(ctx, this)
                 }
             }
@@ -258,7 +258,7 @@ abstract class PaperweightUser : Plugin<Project> {
             defaultDependencies {
                 val ctx = createContext(target)
                 userdevSetup.get().let { setup ->
-                    setup.createOrUpdateIvyRepository(ctx)
+                    setup.createOrUpdateLocalRepositories(ctx)
                     setup.populateRuntimeConfiguration(ctx, this)
                 }
             }

--- a/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
@@ -170,7 +170,18 @@ abstract class PaperweightUser : Plugin<Project> {
     }
 
     private fun Project.configureRepositories(userdevSetup: UserdevSetup) = repositories {
+        // Initial repos
+        val before = toList()
+
+        // Add local repos
         userdevSetup.addLocalRepositories(project)
+
+        // Move local repos to front
+        val new = toList().subtract(before.toSet())
+        new.forEach {
+            remove(it)
+            addFirst(it)
+        }
 
         maven(userdevSetup.paramMappings.url) {
             name = PARAM_MAPPINGS_REPO_NAME

--- a/paperweight-userdev/src/main/kotlin/internal/setup/DevBundleVersions.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/DevBundleVersions.kt
@@ -1,0 +1,54 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2021 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.userdev.internal.setup
+
+import io.papermc.paperweight.PaperweightException
+import io.papermc.paperweight.userdev.internal.setup.v2.DevBundleV2
+import io.papermc.paperweight.userdev.internal.setup.v3.DevBundleV3
+import io.papermc.paperweight.userdev.internal.setup.v4.DevBundleV4
+import kotlin.reflect.KClass
+
+object DevBundleVersions {
+    data class SupportedVersion<C>(
+        val version: Int,
+        val configType: KClass<out Any>,
+        val factory: SetupHandler.Factory<C>
+    )
+
+    val versions: Map<Int, SupportedVersion<*>> = listOf(
+        DevBundleV2.version,
+        DevBundleV3.version,
+        DevBundleV4.version,
+    ).associateBy { it.version }
+
+    val versionsByConfigType: Map<KClass<out Any>, SupportedVersion<*>> = versions.values.associateBy { it.configType }
+
+    fun checkSupported(dataVersion: Int) {
+        if (dataVersion !in versions) {
+            throw PaperweightException(
+                "The paperweight development bundle you are attempting to use is of data version '$dataVersion', but" +
+                    " the currently running version of paperweight only supports data versions '${versions.keys}'."
+            )
+        }
+    }
+}

--- a/paperweight-userdev/src/main/kotlin/internal/setup/UserdevSetup.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/UserdevSetup.kt
@@ -24,12 +24,12 @@ package io.papermc.paperweight.userdev.internal.setup
 
 import io.papermc.paperweight.DownloadService
 import io.papermc.paperweight.util.*
-import io.papermc.paperweight.util.constants.IVY_REPOSITORY
-import io.papermc.paperweight.util.constants.paperSetupOutput
+import io.papermc.paperweight.util.constants.*
 import java.nio.file.Path
 import org.gradle.api.Project
 import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
@@ -61,8 +61,12 @@ abstract class UserdevSetup : BuildService<UserdevSetup.Parameters>, SetupHandle
     private fun createSetup(): SetupHandler =
         SetupHandler.create(this, extractDevBundle)
 
-    fun addIvyRepository(project: Project) {
+    fun addLocalRepositories(project: Project) {
         project.repositories {
+            maven {
+                setUrl(parameters.cache.path.resolve(MAVEN_REPOSITORY))
+                configureMavenRepo(this)
+            }
             setupIvyRepository(parameters.cache.path.resolve(IVY_REPOSITORY)) {
                 configureIvyRepo(this)
             }
@@ -70,12 +74,16 @@ abstract class UserdevSetup : BuildService<UserdevSetup.Parameters>, SetupHandle
     }
 
     // begin delegate to setup
-    override fun createOrUpdateIvyRepository(context: SetupHandler.Context) {
-        setup.createOrUpdateIvyRepository(context)
+    override fun createOrUpdateLocalRepositories(context: SetupHandler.Context) {
+        setup.createOrUpdateLocalRepositories(context)
     }
 
     override fun configureIvyRepo(repo: IvyArtifactRepository) {
         setup.configureIvyRepo(repo)
+    }
+
+    override fun configureMavenRepo(repo: MavenArtifactRepository) {
+        setup.configureMavenRepo(repo)
     }
 
     override fun populateCompileConfiguration(context: SetupHandler.Context, dependencySet: DependencySet) {

--- a/paperweight-userdev/src/main/kotlin/internal/setup/step/ExtractFromBundlerStep.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/step/ExtractFromBundlerStep.kt
@@ -1,0 +1,55 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2021 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.userdev.internal.setup.step
+
+import io.papermc.paperweight.tasks.ServerBundler
+import io.papermc.paperweight.userdev.internal.setup.SetupHandler
+import io.papermc.paperweight.userdev.internal.setup.util.HashFunctionBuilder
+import java.nio.file.Path
+
+class ExtractFromBundlerStep(
+    override val hashFile: Path,
+    private val vanillaSteps: VanillaSteps,
+    private val vanillaServerJar: Path,
+    private val minecraftLibraryJars: Path,
+    private val listMinecraftLibraryJars: () -> List<Path>,
+) : SetupStep {
+    override val name: String = "extract libraries and server from downloaded jar"
+
+    override fun run(context: SetupHandler.Context) {
+        ServerBundler.extractFromBundler(
+            vanillaSteps.mojangJar,
+            vanillaServerJar,
+            minecraftLibraryJars,
+            null,
+            null,
+            null,
+            null,
+        )
+    }
+
+    override fun touchHashFunctionBuilder(builder: HashFunctionBuilder) {
+        builder.include(vanillaSteps.mojangJar, vanillaServerJar)
+        builder.include(listMinecraftLibraryJars())
+    }
+}

--- a/paperweight-userdev/src/main/kotlin/internal/setup/step/SetupArchivedPublications.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/step/SetupArchivedPublications.kt
@@ -1,0 +1,61 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2021 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.userdev.internal.setup.step
+
+import io.papermc.paperweight.PaperweightException
+import io.papermc.paperweight.userdev.internal.setup.SetupHandler
+import io.papermc.paperweight.userdev.internal.setup.util.HashFunctionBuilder
+import io.papermc.paperweight.userdev.internal.setup.util.hashDirectory
+import io.papermc.paperweight.util.copyRecursivelyTo
+import io.papermc.paperweight.util.deleteRecursively
+import io.papermc.paperweight.util.openZip
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+
+class SetupArchivedPublications(
+    private val maven: Path,
+    @Input private val archivedPublications: List<String>,
+    private val archivedPublicationsDir: Path,
+    override val hashFile: Path,
+) : SetupStep {
+    override val name: String = "extract included publications"
+
+    override fun run(context: SetupHandler.Context) {
+        maven.deleteRecursively()
+        maven.createDirectories()
+        for (name in archivedPublications) {
+            try {
+                archivedPublicationsDir.resolve("$name.zip").openZip().use { fs ->
+                    fs.getPath("/").copyRecursivelyTo(maven)
+                }
+            } catch (ex: Exception) {
+                throw PaperweightException("Failed to extract archived publication '$name'", ex)
+            }
+        }
+    }
+
+    override fun touchHashFunctionBuilder(builder: HashFunctionBuilder) {
+        builder.include(hashDirectory(archivedPublicationsDir))
+        builder.include(hashDirectory(maven))
+    }
+}

--- a/paperweight-userdev/src/main/kotlin/internal/setup/util/utils.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/util/utils.kt
@@ -72,8 +72,12 @@ fun hashFiles(files: List<Path>): String = files.asSequence()
         "${it.fileName.pathString}:${it.sha256asHex()}"
     }
 
-fun hashDirectory(dir: Path): String =
-    Files.walk(dir).use { stream -> hashFiles(stream.filter { it.isRegularFile() }.collect(Collectors.toList())) }
+fun hashDirectory(dir: Path): String {
+    if (!dir.isDirectory()) {
+        return ""
+    }
+    return Files.walk(dir).use { stream -> hashFiles(stream.filter { it.isRegularFile() }.collect(Collectors.toList())) }
+}
 
 fun DownloadService.download(
     downloadName: String,

--- a/paperweight-userdev/src/main/kotlin/internal/setup/v3/DevBundleV3.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/v3/DevBundleV3.kt
@@ -20,14 +20,14 @@
  * USA
  */
 
-package io.papermc.paperweight.userdev.internal.setup.v2
+package io.papermc.paperweight.userdev.internal.setup.v3
 
 import io.papermc.paperweight.extension.Relocation
 import io.papermc.paperweight.userdev.internal.setup.DevBundleVersions
 import io.papermc.paperweight.util.*
 
-object DevBundleV2 {
-    val version = DevBundleVersions.SupportedVersion(2, Config::class, SetupHandlerImplV2) // 1.17.1
+object DevBundleV3 {
+    val version = DevBundleVersions.SupportedVersion(3, Config::class, SetupHandlerImplV3)
 
     data class Config(
         val minecraftVersion: String,
@@ -36,7 +36,7 @@ object DevBundleV2 {
         val mojangApiCoordinates: String,
         val buildData: BuildData,
         val decompile: Runner,
-        val remap: Runner,
+        val remapper: MavenDep,
         val patchDir: String
     )
 
@@ -46,10 +46,12 @@ object DevBundleV2 {
         val accessTransformFile: String,
         val mojangMappedPaperclipFile: String,
         val vanillaJarIncludes: List<String>,
-        val vanillaServerLibraries: List<String>,
-        val libraryDependencies: Set<String>,
+        val compileDependencies: List<String>,
+        val runtimeDependencies: List<String>,
         val libraryRepositories: List<String>,
-        val relocations: List<Relocation>
+        val relocations: List<Relocation>,
+        val minecraftRemapArgs: List<String>,
+        val pluginRemapArgs: List<String>,
     )
 
     data class Runner(val dep: MavenDep, val args: List<String>)

--- a/paperweight-userdev/src/main/kotlin/internal/setup/v3/SetupHandlerImplV3.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/v3/SetupHandlerImplV3.kt
@@ -190,18 +190,13 @@ class SetupHandlerImplV3(
     }
 
     override fun populateRuntimeConfiguration(context: SetupHandler.Context, dependencySet: DependencySet) {
-        listOf(
+        val list = mutableListOf(
             bundle.config.mappedServerCoordinates,
             bundle.config.apiCoordinates,
             bundle.config.mojangApiCoordinates
-        ).forEach { coordinate ->
-            val dep = context.project.dependencies.create(coordinate).also {
-                (it as ExternalModuleDependency).isTransitive = false
-            }
-            dependencySet.add(dep)
-        }
-
-        for (coordinates in bundle.config.buildData.runtimeDependencies) {
+        )
+        list += bundle.config.buildData.runtimeDependencies
+        for (coordinates in list) {
             val dep = context.project.dependencies.create(coordinates).also {
                 (it as ExternalModuleDependency).isTransitive = false
             }

--- a/paperweight-userdev/src/main/kotlin/internal/setup/v3/SetupHandlerImplV3.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/v3/SetupHandlerImplV3.kt
@@ -22,10 +22,8 @@
 
 package io.papermc.paperweight.userdev.internal.setup.v3
 
-import io.papermc.paperweight.tasks.*
 import io.papermc.paperweight.userdev.internal.setup.*
 import io.papermc.paperweight.userdev.internal.setup.step.*
-import io.papermc.paperweight.userdev.internal.setup.util.HashFunctionBuilder
 import io.papermc.paperweight.util.*
 import io.papermc.paperweight.util.constants.*
 import java.nio.file.Path
@@ -234,39 +232,10 @@ class SetupHandlerImplV3(
         get() = bundle.config.buildData.libraryRepositories
 
     private fun createExtractFromBundlerStep(): ExtractFromBundlerStep = ExtractFromBundlerStep(
-        cache,
+        cache.resolve(paperSetupOutput("extractFromServerBundler", "hashes")),
         vanillaSteps,
         vanillaServerJar,
         minecraftLibraryJars,
         ::minecraftLibraryJars
     )
-
-    private class ExtractFromBundlerStep(
-        cache: Path,
-        private val vanillaSteps: VanillaSteps,
-        private val vanillaServerJar: Path,
-        private val minecraftLibraryJars: Path,
-        private val listMinecraftLibraryJars: () -> List<Path>,
-    ) : SetupStep {
-        override val name: String = "extract libraries and server from downloaded jar"
-
-        override val hashFile: Path = cache.resolve(paperSetupOutput("extractFromServerBundler", "hashes"))
-
-        override fun run(context: SetupHandler.Context) {
-            ServerBundler.extractFromBundler(
-                vanillaSteps.mojangJar,
-                vanillaServerJar,
-                minecraftLibraryJars,
-                null,
-                null,
-                null,
-                null,
-            )
-        }
-
-        override fun touchHashFunctionBuilder(builder: HashFunctionBuilder) {
-            builder.include(vanillaSteps.mojangJar, vanillaServerJar)
-            builder.include(listMinecraftLibraryJars())
-        }
-    }
 }

--- a/paperweight-userdev/src/main/kotlin/internal/setup/v4/DevBundleV4.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/v4/DevBundleV4.kt
@@ -1,0 +1,34 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2021 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.userdev.internal.setup.v4
+
+import io.papermc.paperweight.tasks.*
+import io.papermc.paperweight.userdev.internal.setup.DevBundleVersions
+
+object DevBundleV4 {
+    val version = DevBundleVersions.SupportedVersion(
+        GenerateDevBundle.currentDataVersion,
+        GenerateDevBundle.DevBundleConfig::class,
+        SetupHandlerImplV4
+    )
+}

--- a/paperweight-userdev/src/main/kotlin/internal/setup/v4/SetupHandlerImplV4.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/v4/SetupHandlerImplV4.kt
@@ -28,7 +28,6 @@ import io.papermc.paperweight.userdev.internal.setup.RunPaperclip
 import io.papermc.paperweight.userdev.internal.setup.SetupHandler
 import io.papermc.paperweight.userdev.internal.setup.UserdevSetup
 import io.papermc.paperweight.userdev.internal.setup.step.*
-import io.papermc.paperweight.userdev.internal.setup.util.HashFunctionBuilder
 import io.papermc.paperweight.util.*
 import io.papermc.paperweight.util.constants.*
 import java.nio.file.Path
@@ -255,39 +254,10 @@ class SetupHandlerImplV4(
         get() = bundle.config.buildData.libraryRepositories
 
     private fun createExtractFromBundlerStep(): ExtractFromBundlerStep = ExtractFromBundlerStep(
-        cache,
+        cache.resolve(paperSetupOutput("extractFromServerBundler", "hashes")),
         vanillaSteps,
         vanillaServerJar,
         minecraftLibraryJars,
         ::minecraftLibraryJars
     )
-
-    private class ExtractFromBundlerStep(
-        cache: Path,
-        private val vanillaSteps: VanillaSteps,
-        private val vanillaServerJar: Path,
-        private val minecraftLibraryJars: Path,
-        private val listMinecraftLibraryJars: () -> List<Path>,
-    ) : SetupStep {
-        override val name: String = "extract libraries and server from downloaded jar"
-
-        override val hashFile: Path = cache.resolve(paperSetupOutput("extractFromServerBundler", "hashes"))
-
-        override fun run(context: SetupHandler.Context) {
-            ServerBundler.extractFromBundler(
-                vanillaSteps.mojangJar,
-                vanillaServerJar,
-                minecraftLibraryJars,
-                null,
-                null,
-                null,
-                null,
-            )
-        }
-
-        override fun touchHashFunctionBuilder(builder: HashFunctionBuilder) {
-            builder.include(vanillaSteps.mojangJar, vanillaServerJar)
-            builder.include(listMinecraftLibraryJars())
-        }
-    }
 }

--- a/paperweight-userdev/src/main/kotlin/internal/setup/v4/SetupHandlerImplV4.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/v4/SetupHandlerImplV4.kt
@@ -218,7 +218,7 @@ class SetupHandlerImplV4(
         val coords = mutableListOf(bundle.config.mappedServerCoordinates)
         coords += bundle.config.archivedPublications.values
         coords += bundle.config.buildData.runtimeDependencies
-        coords.forEach { coordinates ->
+        for (coordinates in coords) {
             val dep = context.project.dependencies.create(coordinates).also {
                 (it as ExternalModuleDependency).isTransitive = false
             }


### PR DESCRIPTION
Removes need to special case api & mojangapi, keeps versions in sync, and allows more flexibility for including own project dependencies (forks)

closes #162

known issue:
Included project dependency sources don't auto-attach in intellij on sync, it's needed to open a class and press "Download Sources". Any help with debugging this is greatly appreciated!

current paper changes:
```diff
Index: build.gradle.kts
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle.kts b/build.gradle.kts
--- a/build.gradle.kts	(revision 339e85d4915a7cfa0066e89c0ffa3ea7b983493d)
+++ b/build.gradle.kts	(date 1663909771039)
@@ -5,7 +5,7 @@
     java
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "7.1.2" apply false
-    id("io.papermc.paperweight.core") version "1.3.8"
+    id("io.papermc.paperweight.core") version "1.4.0-LOCAL-SNAPSHOT"
 }
 
 allprojects {
@@ -99,15 +99,24 @@
             "org.spigotmc",
         )
     }
-}
 
-tasks.generateDevelopmentBundle {
-    apiCoordinates.set("io.papermc.paper:paper-api")
-    mojangApiCoordinates.set("io.papermc.paper:paper-mojangapi")
-    libraryRepositories.addAll(
-        "https://repo.maven.apache.org/maven2/",
-        paperMavenPublicUrl,
-    )
+    devBundle {
+        libraryRepositories.addAll(
+            "https://repo.maven.apache.org/maven2/",
+            paperMavenPublicUrl,
+        )
+
+        registerProjectPublication(
+            project(":paper-api"),
+            "maven",
+            "io.papermc.paper:paper-api:$version"
+        )
+        registerProjectPublication(
+            project(":paper-mojangapi"),
+            "maven",
+            "io.papermc.paper:paper-mojangapi:$version"
+        )
+    }
 }
 
 publishing {

```