### PR TITLE
Read ATs from server patch file headers

### DIFF
--- a/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/AllTasks.kt
@@ -46,7 +46,7 @@ open class AllTasks(
 
     val mergeAdditionalAts by tasks.registering<MergeAccessTransforms> {
         firstFile.set(mergeGeneratedAts.flatMap { it.outputFile })
-        secondFile.set(extension.paper.additionalAts.fileExists(project))
+        secondFile.set(mergePaperAts.flatMap { it.outputFile })
     }
 
     val applyMergedAt by tasks.registering<ApplyAccessTransform> {

--- a/paperweight-core/src/main/kotlin/taskcontainers/GeneralTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/GeneralTasks.kt
@@ -50,4 +50,13 @@ open class GeneralTasks(
         inputJar.set(extractFromBundler.flatMap { it.serverJar })
         includes.set(extension.vanillaJarIncludes)
     }
+
+    val collectAtsFromPatches by tasks.registering<CollectATsFromPatches> {
+        patchDir.set(extension.paper.spigotServerPatchDir)
+    }
+
+    val mergePaperAts by tasks.registering<MergeAccessTransforms> {
+        firstFile.set(extension.paper.additionalAts.fileExists(project))
+        secondFile.set(collectAtsFromPatches.flatMap { it.outputFile })
+    }
 }

--- a/paperweight-core/src/main/kotlin/taskcontainers/SpigotTasks.kt
+++ b/paperweight-core/src/main/kotlin/taskcontainers/SpigotTasks.kt
@@ -188,7 +188,7 @@ open class SpigotTasks(
         mojangMappedVanillaJar.set(fixJar.flatMap { it.outputJar })
         vanillaRemappedSpigotJar.set(filterSpigotExcludes.flatMap { it.outputZip })
         spigotDeps.from(downloadSpigotDependencies.map { it.outputDir.asFileTree })
-        additionalAts.set(extension.paper.additionalAts.fileExists(project))
+        additionalAts.set(mergePaperAts.flatMap { it.outputFile })
     }
 
     val remapGeneratedAt by tasks.registering<RemapAccessTransform> {

--- a/paperweight-lib/src/main/kotlin/tasks/CollectATsFromPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/CollectATsFromPatches.kt
@@ -8,14 +8,12 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 abstract class CollectATsFromPatches : BaseTask() {
 
     @get:Input
-    @get:Optional
     abstract val header: Property<String>
 
     @get:InputDirectory

--- a/paperweight-lib/src/main/kotlin/tasks/CollectATsFromPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/CollectATsFromPatches.kt
@@ -1,3 +1,25 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2021 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
 package io.papermc.paperweight.tasks
 
 import io.papermc.paperweight.util.*

--- a/paperweight-lib/src/main/kotlin/tasks/CollectATsFromPatches.kt
+++ b/paperweight-lib/src/main/kotlin/tasks/CollectATsFromPatches.kt
@@ -1,0 +1,52 @@
+package io.papermc.paperweight.tasks
+
+import io.papermc.paperweight.util.*
+import java.nio.file.Path
+import kotlin.io.path.*
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class CollectATsFromPatches : BaseTask() {
+
+    @get:InputDirectory
+    abstract val patchDir: DirectoryProperty
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    override fun init() {
+        outputFile.convention(defaultOutput("at"))
+    }
+
+    @TaskAction
+    fun run() {
+        outputFile.path.deleteForcefully()
+        val patches = patchDir.path.listDirectoryEntries("*.patch")
+        outputFile.path.writeLines(readAts(patches))
+    }
+
+    private fun readAts(patches: Iterable<Path>) : Set<String> {
+        val result = hashSetOf<String>()
+
+        val start = "== AT =="
+        val end = "diff --git a/"
+        for (patch in patches) {
+            var reading = false
+            for (readLine in patch.readLines()) {
+                if (readLine.startsWith(end)) {
+                    break
+                }
+                if (reading && readLine.isNotBlank()) {
+                    result.add(readLine)
+                }
+                if (readLine.startsWith(start)) {
+                    reading = true
+                }
+            }
+        }
+        return result
+    }
+}


### PR DESCRIPTION
Reads ATs from patch files underneath `== AT ==` and aggregates them with ATs in the dev file. Should clean up the paper AT file by allowing us to move ATs from that one file into their specific patch file.