### PR TITLE
Use DiffPatch to apply patches in userdev, removes git dependency

### DIFF
--- a/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
@@ -21,6 +21,11 @@ repositories {
             includeModule("org.cadixdev", "mercury")
         }
     }
+    maven("https://repo.papermc.io/repository/maven-public/") {
+        mavenContent {
+            includeGroup("net.minecraftforge")
+        }
+    }
     maven("https://maven.quiltmc.org/repository/release/") {
         mavenContent {
             includeGroup("org.quiltmc")

--- a/buildSrc/src/main/kotlin/config-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/config-publish.gradle.kts
@@ -47,7 +47,9 @@ val shadowJar by tasks.existing(ShadowJar::class) {
         "org.objectweb.asm",
         "org.osgi",
         "org.tukaani.xz",
-        "org.slf4j"
+        "org.slf4j",
+        "codechicken.diffpatch",
+        "codechicken.repack"
     ).forEach { pack ->
         relocate(pack, "$prefix.$pack")
     }

--- a/paperweight-lib/build.gradle.kts
+++ b/paperweight-lib/build.gradle.kts
@@ -17,5 +17,5 @@ dependencies {
 
     implementation(libs.jbsdiff)
 
-    implementation("net.minecraftforge:DiffPatch:2.0.+")
+    implementation("net.minecraftforge:DiffPatch:2.0.7:all")
 }

--- a/paperweight-lib/build.gradle.kts
+++ b/paperweight-lib/build.gradle.kts
@@ -17,5 +17,7 @@ dependencies {
 
     implementation(libs.jbsdiff)
 
-    implementation("net.minecraftforge:DiffPatch:2.0.7:all")
+    implementation("net.minecraftforge:DiffPatch:2.0.7:all") {
+        isTransitive = false
+    }
 }

--- a/paperweight-lib/build.gradle.kts
+++ b/paperweight-lib/build.gradle.kts
@@ -16,4 +16,6 @@ dependencies {
     implementation(libs.lorenzTiny)
 
     implementation(libs.jbsdiff)
+
+    implementation("net.minecraftforge:DiffPatch:2.0.+")
 }

--- a/paperweight-lib/src/main/kotlin/util/file.kt
+++ b/paperweight-lib/src/main/kotlin/util/file.kt
@@ -220,3 +220,21 @@ fun acquireProcessLockWaiting(
     lockFile.writeText(currentPid.toString())
     return false
 }
+
+fun relativeCopy(baseDir: Path, file: Path, outputDir: Path) {
+    relativeCopyOrMove(baseDir, file, outputDir, false)
+}
+
+fun relativeMove(baseDir: Path, file: Path, outputDir: Path) {
+    relativeCopyOrMove(baseDir, file, outputDir, true)
+}
+
+private fun relativeCopyOrMove(baseDir: Path, file: Path, outputDir: Path, move: Boolean) {
+    val destination = outputDir.resolve(file.relativeTo(baseDir).invariantSeparatorsPathString)
+    destination.parent.createDirectories()
+    if (move) {
+        file.moveTo(destination, overwrite = true)
+    } else {
+        file.copyTo(destination, overwrite = true)
+    }
+}

--- a/paperweight-userdev/build.gradle.kts
+++ b/paperweight-userdev/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 dependencies {
     shade(projects.paperweightLib)
     implementation(libs.kotson)
+    implementation("net.minecraftforge:DiffPatch:2.0.+")
 }

--- a/paperweight-userdev/build.gradle.kts
+++ b/paperweight-userdev/build.gradle.kts
@@ -6,5 +6,7 @@ plugins {
 dependencies {
     shade(projects.paperweightLib)
     implementation(libs.kotson)
-    implementation("net.minecraftforge:DiffPatch:2.0.7:all")
+    implementation("net.minecraftforge:DiffPatch:2.0.7:all") {
+        isTransitive = false
+    }
 }

--- a/paperweight-userdev/build.gradle.kts
+++ b/paperweight-userdev/build.gradle.kts
@@ -6,5 +6,5 @@ plugins {
 dependencies {
     shade(projects.paperweightLib)
     implementation(libs.kotson)
-    implementation("net.minecraftforge:DiffPatch:2.0.+")
+    implementation("net.minecraftforge:DiffPatch:2.0.7:all")
 }

--- a/paperweight-userdev/src/main/kotlin/internal/setup/step/ApplyDevBundlePatches.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/step/ApplyDevBundlePatches.kt
@@ -77,7 +77,8 @@ class ApplyDevBundlePatches(
                 } catch (ex: Exception) {
                     throw PaperweightException(
                         "Failed to apply dev bundle patches. See the log file at '${log.toFile()}' for more details. " +
-                            "Usually, the issue is with the dev bundle itself, and not the userdev project.", ex
+                            "Usually, the issue is with the dev bundle itself, and not the userdev project.",
+                        ex
                     )
                 }
             }

--- a/paperweight-userdev/src/main/kotlin/internal/setup/step/ApplyDevBundlePatches.kt
+++ b/paperweight-userdev/src/main/kotlin/internal/setup/step/ApplyDevBundlePatches.kt
@@ -24,14 +24,13 @@ package io.papermc.paperweight.userdev.internal.setup.step
 
 import codechicken.diffpatch.cli.PatchOperation
 import codechicken.diffpatch.util.archiver.ArchiveFormat
+import io.papermc.paperweight.PaperweightException
 import io.papermc.paperweight.userdev.internal.setup.SetupHandler
 import io.papermc.paperweight.userdev.internal.setup.util.HashFunctionBuilder
 import io.papermc.paperweight.userdev.internal.setup.util.hashDirectory
 import io.papermc.paperweight.userdev.internal.setup.util.siblingHashesFile
 import io.papermc.paperweight.userdev.internal.setup.util.siblingLogFile
-import io.papermc.paperweight.util.ensureDeleted
-import io.papermc.paperweight.util.findOutputDir
-import io.papermc.paperweight.util.zip
+import io.papermc.paperweight.util.*
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
@@ -73,7 +72,14 @@ class ApplyDevBundlePatches(
                     .patchesPath(tempPatchDir)
                     .outputPath(outputDir)
                     .build()
-                op.operate().throwOnError()
+                try {
+                    op.operate().throwOnError()
+                } catch (ex: Exception) {
+                    throw PaperweightException(
+                        "Failed to apply dev bundle patches. See the log file at '${log.toFile()}' for more details. " +
+                            "Usually, the issue is with the dev bundle itself, and not the userdev project.", ex
+                    )
+                }
             }
 
             Files.walk(tempSourceDir).use { stream ->


### PR DESCRIPTION
This is the tool used in MCPConfig, and is maintained by Forge. The latest 1.19.3 dev bundle as of today applies fine, see the log: https://pastes.dev/I5RxpinIW4

Later on, we can also use DiffPatch to generate the patches, to resolve #65