### PR TITLE
userdev: Deprecate top level dependency functions in favor of DependencyHandler extension

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = io.papermc.paperweight
-version = 1.4.2-SNAPSHOT
+version = 1.5.0-SNAPSHOT
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
@@ -92,7 +92,7 @@ abstract class PaperweightUser : Plugin<Project> {
         )
 
         target.dependencies.extensions.create(
-            "paperweight",
+            PAPERWEIGHT_EXTENSION,
             PaperweightUserDependenciesExtension::class,
             target.dependencies
         )

--- a/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/PaperweightUser.kt
@@ -91,6 +91,12 @@ abstract class PaperweightUser : Plugin<Project> {
             target.objects
         )
 
+        target.dependencies.extensions.create(
+            "paperweight",
+            PaperweightUserDependenciesExtension::class,
+            target.dependencies
+        )
+
         createConfigurations(target, target.provider { userdevSetup })
 
         val reobfJar by target.tasks.registering<RemapJar> {

--- a/paperweight-userdev/src/main/kotlin/PaperweightUserDependenciesExtension.kt
+++ b/paperweight-userdev/src/main/kotlin/PaperweightUserDependenciesExtension.kt
@@ -73,7 +73,7 @@ abstract class PaperweightUserDependenciesExtension(
      * @param configurationAction action configuring the dependency
      */
     @JvmOverloads
-    fun DependencyHandlerScope.devBundle(
+    fun devBundle(
         group: String,
         version: String? = null,
         artifactId: String = "dev-bundle",
@@ -127,7 +127,7 @@ abstract class PaperweightUserDependenciesExtension(
      * @param configurationAction action configuring the dependency
      */
     @JvmOverloads
-    fun DependencyHandlerScope.devBundleDependency(
+    fun devBundleDependency(
         group: String,
         version: String? = null,
         artifactId: String = "dev-bundle",

--- a/paperweight-userdev/src/main/kotlin/PaperweightUserDependenciesExtension.kt
+++ b/paperweight-userdev/src/main/kotlin/PaperweightUserDependenciesExtension.kt
@@ -1,0 +1,152 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2021 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.userdev
+
+import io.papermc.paperweight.util.constants.*
+import org.gradle.api.Action
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.kotlin.dsl.*
+
+abstract class PaperweightUserDependenciesExtension(
+    private val dependencies: DependencyHandler
+) {
+    /**
+     * Adds a dependency on Paper's dev bundle to the dev bundle [org.gradle.api.artifacts.Configuration].
+     *
+     * @param version dependency version
+     * @param group dependency group
+     * @param artifactId dependency artifactId
+     * @param configuration dependency configuration
+     * @param classifier dependency classifier
+     * @param ext dependency extension
+     * @param devBundleConfigurationName name of the dev bundle [org.gradle.api.artifacts.Configuration]
+     * @param configurationAction action configuring the dependency
+     */
+    @JvmOverloads
+    fun paperDevBundle(
+        version: String? = null,
+        group: String = "io.papermc.paper",
+        artifactId: String = "dev-bundle",
+        configuration: String? = null,
+        classifier: String? = null,
+        ext: String? = null,
+        devBundleConfigurationName: String = DEV_BUNDLE_CONFIG,
+        configurationAction: Action<ExternalModuleDependency> = nullAction()
+    ): ExternalModuleDependency {
+        val dep = dependencies.create(group, artifactId, version, configuration, classifier, ext)
+        configurationAction(dep)
+        dependencies.add(devBundleConfigurationName, dep)
+        return dep
+    }
+
+    /**
+     * Adds a dependency to the dev bundle [org.gradle.api.artifacts.Configuration].
+     *
+     * @param group dependency group
+     * @param version dependency version
+     * @param artifactId dependency artifactId
+     * @param configuration dependency configuration
+     * @param classifier dependency classifier
+     * @param ext dependency extension
+     * @param devBundleConfigurationName name of the dev bundle [org.gradle.api.artifacts.Configuration]
+     * @param configurationAction action configuring the dependency
+     */
+    @JvmOverloads
+    fun DependencyHandlerScope.devBundle(
+        group: String,
+        version: String? = null,
+        artifactId: String = "dev-bundle",
+        configuration: String? = null,
+        classifier: String? = null,
+        ext: String? = null,
+        devBundleConfigurationName: String = DEV_BUNDLE_CONFIG,
+        configurationAction: Action<ExternalModuleDependency> = nullAction()
+    ): ExternalModuleDependency {
+        val dep = dependencies.create(group, artifactId, version, configuration, classifier, ext)
+        configurationAction(dep)
+        dependencies.add(devBundleConfigurationName, dep)
+        return dep
+    }
+
+    /**
+     * Creates a Paper dev bundle dependency without adding it to any configurations.
+     *
+     * @param version dependency version
+     * @param group dependency group
+     * @param artifactId dependency artifactId
+     * @param configuration dependency configuration
+     * @param classifier dependency classifier
+     * @param ext dependency extension
+     * @param configurationAction action configuring the dependency
+     */
+    @JvmOverloads
+    fun paperDevBundleDependency(
+        version: String? = null,
+        group: String = "io.papermc.paper",
+        artifactId: String = "dev-bundle",
+        configuration: String? = null,
+        classifier: String? = null,
+        ext: String? = null,
+        configurationAction: Action<ExternalModuleDependency> = nullAction()
+    ): ExternalModuleDependency {
+        val dep = dependencies.create(group, artifactId, version, configuration, classifier, ext)
+        configurationAction(dep)
+        return dep
+    }
+
+    /**
+     * Creates a dev bundle dependency without adding it to any configurations.
+     *
+     * @param group dependency group
+     * @param version dependency version
+     * @param artifactId dependency artifactId
+     * @param configuration dependency configuration
+     * @param classifier dependency classifier
+     * @param ext dependency extension
+     * @param configurationAction action configuring the dependency
+     */
+    @JvmOverloads
+    fun DependencyHandlerScope.devBundleDependency(
+        group: String,
+        version: String? = null,
+        artifactId: String = "dev-bundle",
+        configuration: String? = null,
+        classifier: String? = null,
+        ext: String? = null,
+        configurationAction: Action<ExternalModuleDependency> = nullAction()
+    ): ExternalModuleDependency {
+        val dep = dependencies.create(group, artifactId, version, configuration, classifier, ext)
+        configurationAction(dep)
+        return dep
+    }
+
+    @Suppress("unchecked_cast")
+    private fun <T> nullAction(): Action<T> {
+        return NullAction as Action<T>
+    }
+
+    private object NullAction : Action<Any> {
+        override fun execute(t: Any) {}
+    }
+}

--- a/paperweight-userdev/src/main/kotlin/extensions.kt
+++ b/paperweight-userdev/src/main/kotlin/extensions.kt
@@ -36,6 +36,12 @@ import org.gradle.kotlin.dsl.*
  * @param devBundleConfigurationName name of the dev bundle [org.gradle.api.artifacts.Configuration]
  * @param configurationAction action configuring the dependency
  */
+@Deprecated(
+    message = "Replaced by extension methods",
+    replaceWith = ReplaceWith(
+        "paperweight.paperDevBundle"
+    )
+)
 fun DependencyHandlerScope.paperDevBundle(
     version: String? = null,
     group: String = "io.papermc.paper",
@@ -59,6 +65,12 @@ fun DependencyHandlerScope.paperDevBundle(
  * @param devBundleConfigurationName name of the dev bundle [org.gradle.api.artifacts.Configuration]
  * @param configurationAction action configuring the dependency
  */
+@Deprecated(
+    message = "Replaced by extension methods",
+    replaceWith = ReplaceWith(
+        "paperweight.devBundle"
+    )
+)
 fun DependencyHandlerScope.paperweightDevBundle(
     group: String,
     version: String? = null,


### PR DESCRIPTION
Paper bundle declaration:

```kotlin
dependencies {
  paperDevBundle("1.19.3-R0.1-SNAPSHOT")
}
```
 -> 
```kotlin
dependencies {
  paperweight.paperDevBundle("1.19.3-R0.1-SNAPSHOT")
}
```
Fork bundle declaration:

```kotlin
dependencies {
  paperweightDevBundle("my.fork", "1.19.3-R0.1-SNAPSHOT")
}
```
->
```kotlin
dependencies {
  paperweight.devBundle("my.fork", "1.19.3-R0.1-SNAPSHOT")
}
```

This is slightly less concise for the default case and a Kotlin build script, but is a lot less hacky and has a side-effect of working a little better for Groovy script users.

Bumps the version to 1.5.0 as this adds a new API and will introduce a deprecation warning for many users until they update their script.