### PR TITLE
Add task to scan generated code to make sure versions match

### DIFF
--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ScanJar.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ScanJar.kt
@@ -1,3 +1,25 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2023 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
 package io.papermc.paperweight.tasks
 
 import io.papermc.paperweight.PaperweightException
@@ -54,7 +76,6 @@ abstract class ScanJar : JavaLauncherTask() {
             forkOptions.executable(launcher.executablePath.path.absolutePathString())
         }
         this.queue(queue)
-
     }
 
     abstract fun queue(queue: WorkQueue)

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ScanJar.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ScanJar.kt
@@ -1,0 +1,144 @@
+package io.papermc.paperweight.tasks
+
+import io.papermc.paperweight.PaperweightException
+import io.papermc.paperweight.util.*
+import io.papermc.paperweight.util.constants.*
+import java.nio.file.FileSystem
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.inject.Inject
+import kotlin.io.path.*
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkQueue
+import org.gradle.workers.WorkerExecutor
+import org.objectweb.asm.tree.ClassNode
+
+abstract class ScanJar : JavaLauncherTask() {
+
+    @get:Classpath
+    abstract val jarToScan: RegularFileProperty
+
+    @get:Classpath
+    abstract val classpath: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val log: RegularFileProperty
+
+    @get:Internal
+    abstract val jvmArgs: ListProperty<String>
+
+    @get:Inject
+    abstract val workerExecutor: WorkerExecutor
+
+    override fun init() {
+        super.init()
+
+        jvmArgs.convention(listOf("-Xmx512m"))
+        log.set(layout.cache.resolve(paperTaskOutput("txt")))
+    }
+
+    @TaskAction
+    fun run() {
+        val launcher = launcher.get()
+        val jvmArgs = jvmArgs.get()
+        val queue = workerExecutor.processIsolation {
+            forkOptions.jvmArgs(jvmArgs)
+            forkOptions.executable(launcher.executablePath.path.absolutePathString())
+        }
+        this.queue(queue)
+
+    }
+
+    abstract fun queue(queue: WorkQueue)
+
+    abstract class ScanJarAction<P : ScanJarAction.BaseParameters> : WorkAction<P>, AsmUtil {
+        interface BaseParameters : WorkParameters {
+            val jarToScan: RegularFileProperty
+            val classpath: ConfigurableFileCollection
+            val log: RegularFileProperty
+        }
+
+        protected val log = mutableListOf<String>()
+
+        final override fun execute() {
+            parameters.jarToScan.path.openZip().use { scan ->
+                var fail: Exception? = null
+                val classPathDirs = mutableListOf<Path>()
+                val classPathJars = mutableListOf<FileSystem>()
+                parameters.classpath.forEach {
+                    if (it.isDirectory) {
+                        classPathDirs.add(it.toPath())
+                        return@forEach
+                    }
+                    if (!it.isFile || !it.name.endsWith(".jar")) {
+                        return@forEach
+                    }
+                    try {
+                        classPathJars += it.toPath().openZip()
+                    } catch (ex: Exception) {
+                        ScanJarForBadCalls.logger.error("Failed to open zip $it", ex)
+                        if (fail == null) {
+                            fail = ex
+                        } else {
+                            fail!!.addSuppressed(ex)
+                        }
+                    }
+                }
+                try {
+                    if (fail != null) {
+                        throw PaperweightException("Failed to read classpath jars", fail)
+                    }
+                    val classNodeCache = ClassNodeCache.create(scan, classPathJars, classPathDirs)
+                    scan(scan, classNodeCache)
+                } finally {
+                    var err: Exception? = null
+                    classPathJars.forEach {
+                        try {
+                            it.close()
+                        } catch (ex: Exception) {
+                            ScanJarForBadCalls.logger.error("Failed to close zip $it", ex)
+                            if (err == null) {
+                                err = ex
+                            } else {
+                                err!!.addSuppressed(ex)
+                            }
+                        }
+                    }
+                    if (err != null) {
+                        throw PaperweightException("Failed to close classpath jars", err)
+                    }
+                }
+            }
+            if (!Files.exists(parameters.log.path.parent)) {
+                Files.createDirectories(parameters.log.path.parent)
+            }
+            parameters.log.path.writeLines(log)
+
+            if (log.isNotEmpty()) {
+                throw PaperweightException("Bad code was found, see log file at ${parameters.log.path.toAbsolutePath()}")
+            }
+        }
+
+        private fun scan(scan: FileSystem, classNodeCache: ClassNodeCache) {
+            scan.walk().use { stream ->
+                stream.forEach { file ->
+                    if (!Files.isRegularFile(file) || !file.fileName.toString().endsWith(".class")) {
+                        return@forEach
+                    }
+                    val classNode = classNodeCache.findClass(file.toString()) ?: return@forEach
+                    this.handleClass(classNode, classNodeCache)
+                }
+            }
+        }
+
+        protected abstract fun handleClass(classNode: ClassNode, classNodeCache: ClassNodeCache)
+    }
+}

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ScanJarForBadCalls.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ScanJarForBadCalls.kt
@@ -22,37 +22,14 @@
 
 package io.papermc.paperweight.tasks
 
-import io.papermc.paperweight.PaperweightException
-import io.papermc.paperweight.util.AsmUtil
-import io.papermc.paperweight.util.ClassNodeCache
-import io.papermc.paperweight.util.cache
-import io.papermc.paperweight.util.constants.paperTaskOutput
-import io.papermc.paperweight.util.openZip
-import io.papermc.paperweight.util.path
-import io.papermc.paperweight.util.set
-import io.papermc.paperweight.util.walk
-import java.nio.file.FileSystem
-import java.nio.file.Files
-import java.nio.file.Path
-import javax.inject.Inject
-import kotlin.io.path.absolutePathString
-import kotlin.io.path.writeLines
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.RegularFileProperty
+import io.papermc.paperweight.util.*
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.TaskAction
-import org.gradle.kotlin.dsl.submit
-import org.gradle.workers.WorkAction
-import org.gradle.workers.WorkParameters
-import org.gradle.workers.WorkerExecutor
+import org.gradle.kotlin.dsl.*
+import org.gradle.workers.WorkQueue
 import org.objectweb.asm.Handle
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.AbstractInsnNode
@@ -62,46 +39,16 @@ import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.MethodNode
 
 @CacheableTask
-abstract class ScanJarForBadCalls : JavaLauncherTask() {
+abstract class ScanJarForBadCalls : ScanJar() {
     companion object {
         val logger: Logger = Logging.getLogger(ScanJarForBadCalls::class.java)
     }
 
-    @get:Classpath
-    abstract val jarToScan: RegularFileProperty
-
-    @get:Classpath
-    abstract val classpath: ConfigurableFileCollection
-
-    @get:OutputFile
-    abstract val log: RegularFileProperty
-
-    @get:Internal
-    abstract val jvmArgs: ListProperty<String>
-
-    @get:Inject
-    abstract val workerExecutor: WorkerExecutor
-
     @get:Input
     abstract val badAnnotations: SetProperty<String>
 
-    override fun init() {
-        super.init()
-
-        jvmArgs.convention(listOf("-Xmx512m"))
-        log.set(layout.cache.resolve(paperTaskOutput("txt")))
-    }
-
-    @TaskAction
-    fun run() {
-        val launcher = launcher.get()
-        val jvmArgs = jvmArgs.get()
-        val queue = workerExecutor.processIsolation {
-            forkOptions.jvmArgs(jvmArgs)
-            forkOptions.executable(launcher.executablePath.path.absolutePathString())
-        }
-
-        queue.submit(ScanJarAction::class) {
+    override fun queue(queue: WorkQueue) {
+        queue.submit(ScanJarForBadCallsAction::class) {
             jarToScan.set(this@ScanJarForBadCalls.jarToScan)
             classpath.from(this@ScanJarForBadCalls.classpath)
             log.set(this@ScanJarForBadCalls.log)
@@ -109,87 +56,14 @@ abstract class ScanJarForBadCalls : JavaLauncherTask() {
         }
     }
 
-    abstract class ScanJarAction : WorkAction<ScanJarAction.Parameters>, AsmUtil {
-        interface Parameters : WorkParameters {
-            val jarToScan: RegularFileProperty
-            val classpath: ConfigurableFileCollection
-            val log: RegularFileProperty
+    abstract class ScanJarForBadCallsAction : ScanJarAction<ScanJarForBadCallsAction.Parameters>(), AsmUtil {
+        interface Parameters : BaseParameters {
             val badAnnotations: SetProperty<String>
         }
 
-        private val log = mutableListOf<String>()
-
-        override fun execute() {
-            parameters.jarToScan.path.openZip().use { scan ->
-                var fail: Exception? = null
-                val classPathDirs = mutableListOf<Path>()
-                val classPathJars = mutableListOf<FileSystem>()
-                parameters.classpath.forEach {
-                    if (it.isDirectory) {
-                        classPathDirs.add(it.toPath())
-                        return@forEach
-                    }
-                    if (!it.isFile || !it.name.endsWith(".jar")) {
-                        return@forEach
-                    }
-                    try {
-                        classPathJars += it.toPath().openZip()
-                    } catch (ex: Exception) {
-                        logger.error("Failed to open zip $it", ex)
-                        if (fail == null) {
-                            fail = ex
-                        } else {
-                            fail!!.addSuppressed(ex)
-                        }
-                    }
-                }
-                try {
-                    if (fail != null) {
-                        throw PaperweightException("Failed to read classpath jars", fail)
-                    }
-                    val classNodeCache = ClassNodeCache.create(scan, classPathJars, classPathDirs)
-                    scan(scan, classNodeCache)
-                } finally {
-                    var err: Exception? = null
-                    classPathJars.forEach {
-                        try {
-                            it.close()
-                        } catch (ex: Exception) {
-                            logger.error("Failed to close zip $it", ex)
-                            if (err == null) {
-                                err = ex
-                            } else {
-                                err!!.addSuppressed(ex)
-                            }
-                        }
-                    }
-                    if (err != null) {
-                        throw PaperweightException("Failed to close classpath jars", err)
-                    }
-                }
-            }
-            if (!Files.exists(parameters.log.path.parent)) {
-                Files.createDirectories(parameters.log.path.parent)
-            }
-            parameters.log.path.writeLines(log)
-
-            if (log.isNotEmpty()) {
-                throw PaperweightException("Bad method usages were found, see log file at ${parameters.log.path.toAbsolutePath()}")
-            }
-        }
-
-        private fun scan(scan: FileSystem, classNodeCache: ClassNodeCache) {
-            scan.walk().use { stream ->
-                stream.forEach { file ->
-                    if (!Files.isRegularFile(file) || !file.fileName.toString().endsWith(".class")) {
-                        return@forEach
-                    }
-                    val classNode = classNodeCache.findClass(file.toString()) ?: return@forEach
-
-                    for (method in classNode.methods) {
-                        method.instructions.forEach { handleInstruction(classNode, method, it, classNodeCache) }
-                    }
-                }
+        override fun handleClass(classNode: ClassNode, classNodeCache: ClassNodeCache) {
+            for (method in classNode.methods) {
+                method.instructions.forEach { handleInstruction(classNode, method, it, classNodeCache) }
             }
         }
 

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ScanJarForOldGeneratedCode.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ScanJarForOldGeneratedCode.kt
@@ -1,3 +1,25 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2023 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
 package io.papermc.paperweight.tasks
 
 import io.papermc.paperweight.util.*

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ScanJarForOldGeneratedCode.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ScanJarForOldGeneratedCode.kt
@@ -1,0 +1,64 @@
+package io.papermc.paperweight.tasks
+
+import io.papermc.paperweight.util.*
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.kotlin.dsl.*
+import org.gradle.workers.WorkQueue
+import org.objectweb.asm.tree.ClassNode
+
+@CacheableTask
+abstract class ScanJarForOldGeneratedCode : ScanJar() {
+    companion object {
+        val logger: Logger = Logging.getLogger(ScanJarForOldGeneratedCode::class.java)
+    }
+
+    @get:Input
+    abstract val mcVersion: Property<String>
+
+    @get:Input
+    abstract val annotation: Property<String>
+
+    override fun queue(queue: WorkQueue) {
+        queue.submit(ScanJarForOldGeneratedCodeAction::class) {
+            jarToScan.set(this@ScanJarForOldGeneratedCode.jarToScan)
+            classpath.from(this@ScanJarForOldGeneratedCode.classpath)
+            log.set(this@ScanJarForOldGeneratedCode.log)
+            mcVersion.set(this@ScanJarForOldGeneratedCode.mcVersion)
+            annotation.set(this@ScanJarForOldGeneratedCode.annotation)
+        }
+    }
+
+    abstract class ScanJarForOldGeneratedCodeAction : ScanJarAction<ScanJarForOldGeneratedCodeAction.Parameters>() {
+        interface Parameters : BaseParameters {
+            val mcVersion: Property<String>
+            val annotation: Property<String>
+        }
+
+        override fun handleClass(classNode: ClassNode, classNodeCache: ClassNodeCache) {
+            val annotations = (classNode.visibleAnnotations ?: emptyList()) + (classNode.invisibleAnnotations ?: emptyList())
+
+            val generatedAnnotation = annotations
+                .find { it.desc == parameters.annotation.get() }
+                ?.values
+                ?.chunked(2)
+                ?.find { it[0] == "value" } ?: return
+
+            val generatedVersion = generatedAnnotation[1].toString()
+            val mcVersion = parameters.mcVersion.get()
+
+            if (generatedVersion != mcVersion) {
+                val msg = errorMsg(classNode, generatedVersion, mcVersion)
+                log += msg
+                logger.error(msg)
+            }
+        }
+
+        private fun errorMsg(classNode: ClassNode, generatedVersion: String, mcVersion: String): String {
+            return "Class ${classNode.name} is marked as being generated in version $generatedVersion when the set version is $mcVersion"
+        }
+    }
+}


### PR DESCRIPTION
Abstracts a lot of the ScanJar logic into a base task that the bad calls task extends. 

Also adds a new task to check generated code based on a version and annotation. 

Required for https://github.com/PaperMC/Paper/pull/9233