### PR TITLE
fix FilterProjectDir vanillaJar input (fixes runDev in Paper)

### DIFF
--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/project-util.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/project-util.kt
@@ -43,7 +43,7 @@ import org.gradle.plugins.ide.idea.model.IdeaModel
 
 fun Project.setupServerProject(
     parent: Project,
-    remappedJar: Any,
+    remappedJar: Provider<RegularFile>,
     remappedJarSources: Any,
     mcDevSourceDir: Path,
     libsFile: Any,
@@ -64,7 +64,7 @@ fun Project.setupServerProject(
     val filterProjectDir by tasks.registering<FilterProjectDir> {
         inputSrcDir.set(file("src/main/java"))
         inputResourcesDir.set(file("src/main/resources"))
-        vanillaJar.set(parent.file(remappedJar))
+        vanillaJar.set(remappedJar)
         outputJar.set(parent.layout.cache.resolve(FINAL_FILTERED_REMAPPED_JAR))
     }
 

--- a/paperweight-patcher/src/main/kotlin/io/papermc/paperweight/patcher/PaperweightPatcher.kt
+++ b/paperweight-patcher/src/main/kotlin/io/papermc/paperweight/patcher/PaperweightPatcher.kt
@@ -169,7 +169,7 @@ class PaperweightPatcher : Plugin<Project> {
 
             val (_, reobfJar) = serverProj.setupServerProject(
                 target,
-                upstreamData.map { it.remappedJar },
+                upstreamData.map { it.remappedJar }.convertToFileProvider(target.layout, target.providers),
                 upstreamData.map { it.decompiledJar },
                 patcher.mcDevSourceDir.path,
                 upstreamData.map { it.libFile },


### PR DESCRIPTION
Use a proper provider to get the lineMapped jar instead of just relying on it existing in the file tree.