### PR TITLE
Apply a specific rule to exclude JUnit

### DIFF
--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUser.kt
@@ -194,7 +194,7 @@ abstract class PaperweightUser : Plugin<Project> {
 
     private fun Project.applyJunitExclusionRule() = dependencies {
         components {
-            withModule<JunitExclusionRule>("com.googlecode.json-simple:json-simple")
+            withModule<JunitExclusionRule>(JunitExclusionRule.TARGET)
         }
     }
 

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUser.kt
@@ -26,6 +26,7 @@ import io.papermc.paperweight.DownloadService
 import io.papermc.paperweight.PaperweightException
 import io.papermc.paperweight.tasks.*
 import io.papermc.paperweight.userdev.attribute.Obfuscation
+import io.papermc.paperweight.userdev.internal.JunitExclusionRule
 import io.papermc.paperweight.userdev.internal.setup.SetupHandler
 import io.papermc.paperweight.userdev.internal.setup.UserdevSetup
 import io.papermc.paperweight.userdev.internal.setup.util.*
@@ -166,6 +167,10 @@ abstract class PaperweightUser : Plugin<Project> {
                 }
             }
 
+            if (userdev.applyJunitExclusionRule.get()) {
+                applyJunitExclusionRule()
+            }
+
             // Print a friendly error message if the dev bundle is missing before we call anything else that will try and resolve it
             checkForDevBundle()
 
@@ -184,6 +189,12 @@ abstract class PaperweightUser : Plugin<Project> {
         tasks.named("jar", Jar::class, op)
         if ("shadowJar" in tasks.names) {
             tasks.named("shadowJar", Jar::class, op)
+        }
+    }
+
+    private fun Project.applyJunitExclusionRule() = dependencies {
+        components {
+            withModule<JunitExclusionRule>("com.googlecode.json-simple:json-simple")
         }
     }
 
@@ -262,7 +273,6 @@ abstract class PaperweightUser : Plugin<Project> {
         makeRemapperConfig(PLUGIN_REMAPPER_CONFIG)
 
         val mojangMappedServerConfig = target.configurations.register(MOJANG_MAPPED_SERVER_CONFIG) {
-            exclude("junit", "junit") // json-simple exposes junit for some reason
             defaultDependencies {
                 val ctx = createContext(target)
                 userdevSetup.get().let { setup ->

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUserExtension.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUserExtension.kt
@@ -51,9 +51,9 @@ abstract class PaperweightUserExtension(
     val injectPaperRepository: Property<Boolean> = objects.property<Boolean>().convention(true)
 
     /**
-     * Whether to patch dependencies to exclude `junit:junit` from the transitive dependencies.
+     * Whether to patch dependencies to exclude `junit:junit` from the transitive dependencies of `com.googlecode.json-simple:json-simple`.
      *
-     * True by default to avoid `junit:junit` appearing on the `compileClasspath`.
+     * True by default to avoid `junit:junit` appearing on the `compileClasspath` with older versions of Paper.
      */
     val applyJunitExclusionRule: Property<Boolean> = objects.property<Boolean>().convention(true)
 

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUserExtension.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUserExtension.kt
@@ -51,6 +51,13 @@ abstract class PaperweightUserExtension(
     val injectPaperRepository: Property<Boolean> = objects.property<Boolean>().convention(true)
 
     /**
+     * Whether to patch dependencies to exclude `junit:junit` from the transitive dependencies.
+     *
+     * True by default to avoid `junit:junit` appearing on the `compileClasspath`.
+     */
+    val applyJunitExclusionRule: Property<Boolean> = objects.property<Boolean>().convention(true)
+
+    /**
      * The [ReobfArtifactConfiguration] is responsible for setting the input and output jars for `reobfJar`,
      * as well as changing the classifiers of other jars (i.e. `jar` or `shadowJar`).
      */

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/JunitExclusionRule.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/JunitExclusionRule.kt
@@ -31,6 +31,10 @@ import org.gradle.api.artifacts.ComponentMetadataRule
  */
 @CacheableRule
 abstract class JunitExclusionRule : ComponentMetadataRule {
+    companion object {
+        const val TARGET = "com.googlecode.json-simple:json-simple"
+    }
+
     override fun execute(ctx: ComponentMetadataContext) {
         ctx.details.allVariants {
             withDependencies {

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/JunitExclusionRule.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/JunitExclusionRule.kt
@@ -1,0 +1,43 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2023 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.userdev.internal
+
+import org.gradle.api.artifacts.CacheableRule
+import org.gradle.api.artifacts.ComponentMetadataContext
+import org.gradle.api.artifacts.ComponentMetadataRule
+
+/**
+ * Excludes `junit:junit` from the transitive dependencies of all variants.
+ */
+@CacheableRule
+abstract class JunitExclusionRule : ComponentMetadataRule {
+    override fun execute(ctx: ComponentMetadataContext) {
+        ctx.details.allVariants {
+            withDependencies {
+                removeIf {
+                    it.group == "junit" && it.name == "junit"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This avoids excluding junit from the test classpath, even if explicitly added by a downstream user, which doesn't make sense, and allows people to add junit to the main classpath if they need to for some reason.