### PR TITLE
add supported environment check for GenerateDevBundle

### DIFF
--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/taskcontainers/DevBundleTasks.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/taskcontainers/DevBundleTasks.kt
@@ -58,6 +58,8 @@ class DevBundleTasks(
         decompilerConfig.set(project.configurations.named(DECOMPILER_CONFIG))
 
         devBundleFile.set(project.layout.buildDirectory.file("libs/paperweight-development-bundle-${project.version}.zip"))
+
+        ignoreUnsupportedEnvironment.set(project.providers.gradleProperty(GenerateDevBundle.unsupportedEnvironmentPropName).map { it.toBoolean() })
     }
 
     fun configure(

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/file.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/file.kt
@@ -154,7 +154,7 @@ fun FileSystem.walk(): Stream<Path> {
         .flatMap { Files.walk(it) }
 }
 
-fun ProcessBuilder.directory(path: Path): ProcessBuilder = directory(path.toFile())
+fun ProcessBuilder.directory(path: Path?): ProcessBuilder = directory(path?.toFile())
 
 fun Path.hashFile(algorithm: HashingAlgorithm): ByteArray = inputStream().use { input -> input.hash(algorithm) }
 

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/utils.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/utils.kt
@@ -45,6 +45,7 @@ import java.util.IdentityHashMap
 import java.util.Locale
 import java.util.Optional
 import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.io.path.*
 import org.cadixdev.lorenz.merge.MergeResult
 import org.gradle.api.Project
@@ -127,6 +128,8 @@ val Project.isBaseExecution: Boolean
         .map { it == "false" }
         .get()
 
+val redirectThreadCount: AtomicLong = AtomicLong(0)
+
 fun redirect(input: InputStream, out: OutputStream): Thread {
     return Thread {
         try {
@@ -135,6 +138,7 @@ fun redirect(input: InputStream, out: OutputStream): Thread {
             throw PaperweightException("", e)
         }
     }.apply {
+        name = "paperweight stream redirect thread #${redirectThreadCount.getAndIncrement()}"
         isDaemon = true
         start()
     }


### PR DESCRIPTION
bypass the check with `-Ppaperweight.generateDevBundle.ignoreUnsupportedEnvironment=true`

this PR also fixes issues with platform path separators and file tree walk order in the relocation logic, as well as improves error handling

supercedes #212 