### PR TITLE
Rewrite ExplicitThisAdder handling for instance methods/fields

### DIFF
--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/RemapSources.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/RemapSources.kt
@@ -22,6 +22,7 @@
 
 package io.papermc.paperweight.tasks
 
+import io.papermc.paperweight.PaperweightException
 import io.papermc.paperweight.util.*
 import io.papermc.paperweight.util.constants.*
 import java.nio.file.Files
@@ -382,7 +383,7 @@ abstract class RemapSources : JavaLauncherTask() {
 
                     if (!accessibleTargetCls.isCastCompatible(accessible[0])) {
                         val name = getNameNode(accessibleTargetCls)
-                            ?: return@also
+                            ?: throw PaperweightException("Could not find name node for ${accessibleTargetCls.qualifiedName}")
                         thisExpr.qualifier = rewrite.createCopyTarget(name) as Name
                     }
                 }


### PR DESCRIPTION
Tested with https://github.com/PaperMC/Paper/pull/9861

[Paper-Server/src diff](https://paste.gg/p/anonymous/2ae6ad6314ee4a43a6539d43144b5ea0)
[Server patches diff](https://paste.gg/p/anonymous/22c3b92ef7e94e8996b0be7f0e7ca18e)

Closes #106, we should just open new issues for any edge cases we discover

Although this targets handling for instance fields/methods, it also indirectly fixes some issues with static handling.