### PR TITLE
Short circuit userdev up-to-date checking on the last step when the dev bundle hasn't changed

### DIFF
--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/SetupHandlerImpl.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/SetupHandlerImpl.kt
@@ -107,6 +107,7 @@ class SetupHandlerImpl(
         )
 
         StepExecutor.executeSteps(
+            bundle.changed,
             context,
             extractStep,
             filterVanillaJarStep,

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/v2/SetupHandlerImplV2.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/v2/SetupHandlerImplV2.kt
@@ -137,6 +137,7 @@ class SetupHandlerImplV2(
         )
 
         StepExecutor.executeSteps(
+            bundle.changed,
             context,
             downloadMcLibs,
             filterVanillaJarStep,


### PR DESCRIPTION
This should be safe both with and without shared caches since the last step (ApplyDevBundlePatches) always includes the paperweight hash for up-to-date checking in the current code.