### PR TITLE
Don't log Git output for patch apply by default

### DIFF
--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/AllTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/AllTasks.kt
@@ -82,7 +82,7 @@ open class AllTasks(
         if (project.isBaseExecution) {
             doNotTrackState("$name should always run when requested as part of the base execution.")
         }
-        printOutput.set(project.isBaseExecution)
+        printOutput.set(project.printApplyPatchesOutput())
 
         branch.set("HEAD")
         upstreamBranch.set("upstream")
@@ -110,7 +110,7 @@ open class AllTasks(
         if (project.isBaseExecution) {
             doNotTrackState("$name should always run when requested as part of the base execution.")
         }
-        printOutput.set(project.isBaseExecution)
+        printOutput.set(project.printApplyPatchesOutput())
 
         patchDir.set(extension.paper.spigotServerPatchDir)
         remappedSource.set(remapSpigotSources.flatMap { it.sourcesOutputZip })

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ApplyGitPatches.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ApplyGitPatches.kt
@@ -155,8 +155,14 @@ fun ControllableOutputTask.applyGitPatches(
             patch.copyTo(mailDir.resolve(patch.fileName))
         }
 
-        if (git("am", "--3way", "--ignore-whitespace", tempDir.absolutePathString()).showErrors().run() != 0) {
+        val result = git("am", "--3way", "--ignore-whitespace", tempDir.absolutePathString()).captureOut()
+        if (result.exit != 0) {
             statusFile.writeText("1")
+
+            if (!printOutput) {
+                // Log the output anyway on failure
+                logger.lifecycle(result.out)
+            }
             logger.error("***   Please review above details and finish the apply then")
             logger.error("***   save the changes with `./gradlew rebuildPatches`")
 

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ControllableOutputTask.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ControllableOutputTask.kt
@@ -23,6 +23,8 @@
 package io.papermc.paperweight.tasks
 
 import io.papermc.paperweight.util.*
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Console
 
@@ -46,5 +48,22 @@ abstract class ControllableOutputTask : BaseTask() {
         } else {
             setup(UselessOutputStream, System.out)
         }
+    }
+
+    class Result(val exit: Int, val out: String)
+
+    fun Command.captureOut(): Result = run {
+        val out = ByteArrayOutputStream()
+        if (printOutput.get()) {
+            val combined = System.out + out
+            setup(combined, combined)
+        } else {
+            setup(out, out)
+        }
+        Result(run(), String(out.toByteArray()))
+    }
+
+    private operator fun OutputStream.plus(out: OutputStream): OutputStream {
+        return DelegatingOutputStream(this, out)
     }
 }

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/constants/constants.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/constants/constants.kt
@@ -29,6 +29,7 @@ import org.gradle.api.Task
 
 const val PAPERWEIGHT_EXTENSION = "paperweight"
 const val PAPERWEIGHT_DEBUG = "paperweight.debug"
+const val PAPERWEIGHT_PRINT_APPLY_PATCHES_OUTPUT = "paperweight.printBaseExecutionApplyPatchesOutput"
 
 const val MC_LIBRARY_URL = "https://libraries.minecraft.net/"
 

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/utils.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/utils.kt
@@ -124,11 +124,23 @@ fun commentRegex(): Regex {
     return Regex("\\s*#.*")
 }
 
-val Project.isBaseExecution: Boolean
+val Project.isBaseExecutionProvider: Provider<Boolean>
     get() = providers.gradleProperty(PAPERWEIGHT_DOWNSTREAM_FILE_PROPERTY)
         .orElse(provider { "false" })
         .map { it == "false" }
-        .get()
+
+val Project.isBaseExecution: Boolean
+    get() = isBaseExecutionProvider.get()
+
+fun Project.printApplyPatchesOutput(): Provider<Boolean> {
+    val base = isBaseExecutionProvider
+    val showOutput = providers.gradleProperty(PAPERWEIGHT_PRINT_APPLY_PATCHES_OUTPUT)
+        .map { it.toBoolean() }
+        .orElse(false)
+    return base.zip(showOutput) { baseExecution, showOutputProp ->
+        return@zip baseExecution && showOutputProp
+    }
+}
 
 val redirectThreadCount: AtomicLong = AtomicLong(0)
 

--- a/paperweight-patcher/src/main/kotlin/io/papermc/paperweight/patcher/PaperweightPatcher.kt
+++ b/paperweight-patcher/src/main/kotlin/io/papermc/paperweight/patcher/PaperweightPatcher.kt
@@ -261,7 +261,7 @@ class PaperweightPatcher : Plugin<Project> {
             if (isBaseExecution) {
                 doNotTrackState("$name should always run when requested as part of the base execution.")
             }
-            printOutput.set(isBaseExecution)
+            printOutput.set(printApplyPatchesOutput())
 
             val (cloneTask, upstreamDataTask) = upstreamTaskPair
             dependsOn(upstreamDataTask)


### PR DESCRIPTION
On Paper this can get pretty obnoxious with over 1000 server patches...

You can use `paperweight.printBaseExecutionApplyPatchesOutput=true` Gradle property to get the old behavior back.