### PR TITLE
fix(core/patcher): Download Spigot dependencies using DetachedResolver

### DIFF
--- a/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
@@ -41,6 +41,7 @@ repositories {
         }
     }
     mavenCentral()
+    gradlePluginPortal()
 }
 
 dependencies {

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/download-task.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/download-task.kt
@@ -219,7 +219,6 @@ abstract class DownloadSpigotDependencies : BaseTask() {
             }
             config.dependencies.add(
                 dependencyFactory.create(gav).also {
-                    it as ExternalModuleDependency
                     it.artifact {
                         artifact.classifier?.let { s -> classifier = s }
                         artifact.extension?.let { s -> extension = s }
@@ -252,7 +251,6 @@ abstract class DownloadSpigotDependencies : BaseTask() {
         for (component in flatComponents) {
             sourcesConfig.dependencies.add(
                 dependencyFactory.create(component.displayName).also {
-                    it as ExternalModuleDependency
                     it.artifact {
                         classifier = "sources"
                     }

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/download-task.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/download-task.kt
@@ -31,7 +31,6 @@ import javax.inject.Inject
 import javax.xml.parsers.DocumentBuilderFactory
 import kotlin.io.path.*
 import org.gradle.api.DefaultTask
-import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.dsl.DependencyFactory
 import org.gradle.api.attributes.java.TargetJvmEnvironment

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/download-task.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/download-task.kt
@@ -33,6 +33,7 @@ import kotlin.io.path.*
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.artifacts.dsl.DependencyFactory
 import org.gradle.api.attributes.java.TargetJvmEnvironment
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -173,6 +174,9 @@ abstract class DownloadSpigotDependencies : BaseTask() {
     @get:Inject
     abstract val workerExecutor: WorkerExecutor
 
+    @get:Inject
+    abstract val dependencyFactory: DependencyFactory
+
     private val detachedResolver: DetachedResolver = (project as ProjectInternal).newDetachedResolver()
 
     @TaskAction
@@ -214,7 +218,7 @@ abstract class DownloadSpigotDependencies : BaseTask() {
                 }
             }
             config.dependencies.add(
-                project.dependencies.create(gav).also {
+                dependencyFactory.create(gav).also {
                     it as ExternalModuleDependency
                     it.artifact {
                         artifact.classifier?.let { s -> classifier = s }
@@ -247,7 +251,7 @@ abstract class DownloadSpigotDependencies : BaseTask() {
         }
         for (component in flatComponents) {
             sourcesConfig.dependencies.add(
-                project.dependencies.create(component.displayName).also {
+                dependencyFactory.create(component.displayName).also {
                     it as ExternalModuleDependency
                     it.artifact {
                         classifier = "sources"

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/download-task.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/download-task.kt
@@ -173,7 +173,7 @@ abstract class DownloadSpigotDependencies : BaseTask() {
     @get:Inject
     abstract val workerExecutor: WorkerExecutor
 
-    private fun detachedResolver(): DetachedResolver = (project as ProjectInternal).newDetachedResolver()
+    private val detachedResolver: DetachedResolver = (project as ProjectInternal).newDetachedResolver()
 
     @TaskAction
     fun run() {
@@ -195,7 +195,7 @@ abstract class DownloadSpigotDependencies : BaseTask() {
         artifacts += apiSetup.artifacts
         artifacts += serverSetup.artifacts
 
-        val resolver = detachedResolver()
+        val resolver = detachedResolver
         for (repo in spigotRepos) {
             resolver.repositories.maven(repo)
         }

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/data/MavenArtifact.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/data/MavenArtifact.kt
@@ -31,8 +31,8 @@ data class MavenArtifact(
     private val group: String,
     private val artifact: String,
     private val version: String,
-    private val classifier: String? = null,
-    private val extension: String? = null
+    val classifier: String? = null,
+    val extension: String? = null
 ) {
 
     private val classifierText: String
@@ -45,6 +45,9 @@ data class MavenArtifact(
         get() = "${group.replace('.', '/')}/$artifact/$version/$file"
     val file: String
         get() = "$artifact-$version$classifierText.$ext"
+
+    val gav: String
+        get() = "$group:$artifact:$version"
 
     fun downloadToFile(downloadService: DownloadService, targetFile: Path, repos: List<String>) {
         targetFile.parent.createDirectories()


### PR DESCRIPTION
DetachedResolver is currently internal API, but it allows us to solve our problem nicely...

fixes #232