### PR TITLE
feat(userdev): Enable shared caches by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = io.papermc.paperweight
-version = 1.6.4-SNAPSHOT
+version = 1.7.0-SNAPSHOT
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/util/utils.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/util/utils.kt
@@ -208,7 +208,7 @@ fun cleanSharedCaches(target: Project, root: Path) {
                 val pwDir = it.parent.parent // paperweight dir
                 val cacheDir = pwDir.parent // cache dir
                 val lock = cacheDir.resolve(USERDEV_SETUP_LOCK)
-                if (lock.exists()) {
+                if (lock.exists() && ProcessHandle.of(lock.readText().toLong()).isPresent) {
                     return@mapNotNull null
                 }
                 val lastUsed = it.readText().toLong()


### PR DESCRIPTION
Removes experimental from shared caches and enables them by default, also adds a check for the setup lock to avoid an edge case issue when cleaning the shared caches.