### PR TITLE
Check for long paths on Windows

### DIFF
--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/GenerateDevBundle.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/GenerateDevBundle.kt
@@ -29,7 +29,6 @@ import io.papermc.paperweight.util.*
 import io.papermc.paperweight.util.constants.*
 import io.papermc.paperweight.util.data.*
 import java.io.ByteArrayOutputStream
-import java.nio.charset.Charset
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Locale
@@ -318,9 +317,6 @@ abstract class GenerateDevBundle : DefaultTask() {
 
         return asString(outBytes)
     }
-
-    private fun asString(out: ByteArrayOutputStream) = String(out.toByteArray(), Charset.defaultCharset())
-        .replace(System.getProperty("line.separator"), "\n")
 
     @Suppress("SameParameterValue")
     private fun createBundleConfig(dataTargetDir: String, patchTargetDir: String): DevBundleConfig {

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/project-util.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/project-util.kt
@@ -50,6 +50,8 @@ fun Project.setupServerProject(
     packagesToFix: Provider<List<String>?>,
     reobfMappings: Provider<RegularFile>,
 ): ServerTasks? {
+    testPathLength(layout)
+
     if (!projectDir.exists()) {
         return null
     }

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/project-util.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/project-util.kt
@@ -50,7 +50,7 @@ fun Project.setupServerProject(
     packagesToFix: Provider<List<String>?>,
     reobfMappings: Provider<RegularFile>,
 ): ServerTasks? {
-    testPathLength(layout)
+    testPathLength(providers)
 
     if (!projectDir.exists()) {
         return null

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/utils.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/utils.kt
@@ -348,6 +348,35 @@ fun FileCollection.toJarClassProviderRoots(): List<ClassProviderRoot> = files.as
     .map { p -> ClassProviderRoot.fromJar(p) }
     .toList()
 
+// Longest path as of 1.20.4
+private const val longestPath: String =
+    "paperweight/mc-dev-sources/data/minecraft/datapacks/update_1_21/data/minecraft/advancements/" +
+        "recipes/building_blocks/waxed_weathered_chiseled_copper_from_waxed_weathered_cut_copper_stonecutting.json"
+
+fun testPathLength(projectLayout: ProjectLayout) {
+    if (System.getProperty("os.name").lowercase().contains("win")) {
+        val tmpProjDir = projectLayout.projectDirectory.path.resolveSibling(
+            projectLayout.projectDirectory.path.name + "_"
+        )
+        val cache = tmpProjDir.resolve(".gradle/$CACHE_PATH")
+        val testFile = cache.resolve(longestPath)
+
+        try {
+            testFile.parent.createDirectories()
+            testFile.writeText("test")
+        } catch (e: Exception) {
+            throw PaperweightException(
+                "The directory this project is cloned in is too nested. Either enable long paths in Windows and Git, or use WSL.\n" +
+                    "Windows documentation: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry\n" +
+                    "Git command: git config --global core.longpaths true",
+                e
+            )
+        } finally {
+            tmpProjDir.deleteRecursive()
+        }
+    }
+}
+
 private fun javaVersion(): Int {
     val version = System.getProperty("java.specification.version")
     val parts = version.split("\\.".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/utils.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/utils.kt
@@ -366,9 +366,12 @@ fun testPathLength(projectLayout: ProjectLayout) {
             testFile.writeText("test")
         } catch (e: Exception) {
             throw PaperweightException(
-                "The directory this project is cloned in is too nested. Either enable long paths in Windows and Git, or use WSL.\n" +
-                    "Windows documentation: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry\n" +
-                    "Git command: git config --global core.longpaths true",
+                """The directory this project is cloned in is too nested. Possible solutions:
+1) Move the project to a less nested directory (i.e. C:\Paper)
+2) Enable long paths in Windows and Git:
+    Windows documentation: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+    Git command: git config --global core.longpaths true
+3) Clone and build the project in WSL (this will also improve build speed)""",
                 e
             )
         } finally {


### PR DESCRIPTION
Check registry and git configs to see if long paths are likely to be a problem, and print a warning if so.