### PR TITLE
fix(userdev): invalidate caches for preceding steps when a step fails

### DIFF
--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/step/ApplyDevBundlePatches.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/step/ApplyDevBundlePatches.kt
@@ -76,8 +76,7 @@ class ApplyDevBundlePatches(
                     op.operate().throwOnError()
                 } catch (ex: Exception) {
                     throw PaperweightException(
-                        "Failed to apply dev bundle patches. See the log file at '${log.toFile()}' for more details. " +
-                            "Usually, the issue is with the dev bundle itself, and not the userdev project.",
+                        "Failed to apply dev bundle patches. See the log file at '${log.toFile()}' for more details.",
                         ex
                     )
                 }

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/step/steps.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/step/steps.kt
@@ -22,6 +22,7 @@
 
 package io.papermc.paperweight.userdev.internal.setup.step
 
+import io.papermc.paperweight.PaperweightException
 import io.papermc.paperweight.userdev.internal.setup.SetupHandler
 import io.papermc.paperweight.userdev.internal.setup.UserdevSetup
 import io.papermc.paperweight.userdev.internal.setup.util.HashFunction
@@ -29,6 +30,7 @@ import io.papermc.paperweight.userdev.internal.setup.util.HashFunctionBuilder
 import io.papermc.paperweight.userdev.internal.setup.util.buildHashFunction
 import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.io.path.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
@@ -73,8 +75,15 @@ object StepExecutor {
             }
         }
 
-        for (step in steps) {
-            executeStep(context, step)
+        try {
+            for (step in steps) {
+                executeStep(context, step)
+            }
+        } catch (ex: Exception) {
+            for (step in steps) {
+                step.hashFile.deleteIfExists()
+            }
+            throw PaperweightException("Failed to execute steps, invalidated relevant caches", ex)
         }
     }
 

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/step/steps.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/step/steps.kt
@@ -83,7 +83,7 @@ object StepExecutor {
             for (step in steps) {
                 step.hashFile.deleteIfExists()
             }
-            throw PaperweightException("Failed to execute steps, invalidated relevant caches", ex)
+            throw PaperweightException("Failed to execute steps, invalidated relevant caches. Run with --stacktrace for more details.", ex)
         }
     }
 


### PR DESCRIPTION
a common cause for patch apply failing is decompiling with the wrong jdk, and we don't want to have to manually clean cache to fix it after replacing the jdk