### PR TITLE
Specify myers diff algorithm explicitly

### DIFF
--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/RebuildGitPatches.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/RebuildGitPatches.kt
@@ -97,7 +97,7 @@ abstract class RebuildGitPatches : ControllableOutputTask() {
         git("fetch", "--all", "--prune").runSilently(silenceErr = true)
         git(
             "format-patch",
-            "--zero-commit", "--full-index", "--no-signature", "--no-stat", "-N",
+            "--diff-algorithm=myers", "--zero-commit", "--full-index", "--no-signature", "--no-stat", "-N",
             "-o", patchFolder.absolutePathString(),
             baseRef.get()
         ).executeSilently()
@@ -131,7 +131,7 @@ abstract class RebuildGitPatches : ControllableOutputTask() {
         try {
             for (patch in patchFiles) {
                 futures += executor.submit {
-                    val hasNoChanges = git("diff", "--staged", patch.name).getText().lineSequence()
+                    val hasNoChanges = git("diff", "--diff-algorithm=myers", "--staged", patch.name).getText().lineSequence()
                         .filter { it.startsWith('+') || it.startsWith('-') }
                         .filterNot { it.startsWith("+++") || it.startsWith("---") }
                         .all { it.startsWith("+index") || it.startsWith("-index") }

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/patchremap/PatchApplier.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/patchremap/PatchApplier.kt
@@ -114,7 +114,7 @@ class PatchApplier(
         }
 
         git("update-index", "--refresh").executeSilently()
-        if (git("diff-index", "--quiet", "HEAD", "--").runSilently() == 0) {
+        if (git("diff-index", "--diff-algorithm=myers", "--quiet", "HEAD", "--").runSilently() == 0) {
             return git("log", unmappedBranch, "-1", "--pretty=%B").getText().trim() !=
                 git("log", remappedBranch, "-1", "--pretty=%B").getText().trim()
         }

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/patchremap/PatchApplier.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/patchremap/PatchApplier.kt
@@ -103,7 +103,7 @@ class PatchApplier(
         target.createDirectories()
         git("checkout", remappedBranch).executeSilently()
         git(
-            "format-patch", "--zero-commit", "--full-index", "--no-signature", "--no-stat", "-N", "-o",
+            "format-patch", "--diff-algorith=myers", "--zero-commit", "--full-index", "--no-signature", "--no-stat", "-N", "-o",
             target.absolutePathString(), remappedBaseTag
         ).executeOut()
     }


### PR DESCRIPTION
This is the default Git diff algorithm and by specifying this explicitly we prevent git configs from overriding this setting. As Paper relies on patches generated with Myers, and breaks with other algorithms, it doesn't make sense to allow users to configure this.