### PR TITLE
Guard against invalid remapJar configs

### DIFF
--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/RemapJar.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/RemapJar.kt
@@ -76,6 +76,13 @@ abstract class RemapJar : JavaLauncherTask() {
 
     @TaskAction
     fun run() {
+        if (inputJar.path.absolute().normalize() == outputJar.path.absolute().normalize()) {
+            throw PaperweightException(
+                "Invalid configuration, inputJar and outputJar point to the same path: ${inputJar.path}\n" +
+                    "Consider removing customization of output locations, following the default Gradle conventions."
+            )
+        }
+
         if (toNamespace.get() != fromNamespace.get()) {
             val logFile = layout.cache.resolve(paperTaskOutput("log"))
             TinyRemapper.run(


### PR DESCRIPTION
Proactively throw an error when input and output paths match instead of letting tiny-remapper fail.