### PR TITLE
Always make mc-dev-sources when applying patches

### DIFF
--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ApplyPaperPatches.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ApplyPaperPatches.kt
@@ -165,9 +165,11 @@ abstract class ApplyPaperPatches : ControllableOutputTask() {
             git("tag", "-d", "base").runSilently(silenceErr = true)
             git("tag", "base").executeSilently()
 
-            applyGitPatches(git, target, outputFile, patchDir.path, printOutput.get(), verbose.get())
-
-            makeMcDevSrc(layout.cache, sourceMcDevJar.path, mcDevSources.path, outputDir.path, sourceDir, mcDataDir)
+            try {
+                applyGitPatches(git, target, outputFile, patchDir.path, printOutput.get(), verbose.get())
+            } finally {
+                makeMcDevSrc(layout.cache, sourceMcDevJar.path, mcDevSources.path, outputDir.path, sourceDir, mcDataDir)
+            }
         }
     }
 

--- a/paperweight-patcher/src/main/kotlin/io/papermc/paperweight/patcher/tasks/PatcherApplyGitPatches.kt
+++ b/paperweight-patcher/src/main/kotlin/io/papermc/paperweight/patcher/tasks/PatcherApplyGitPatches.kt
@@ -161,8 +161,10 @@ abstract class PatcherApplyGitPatches : ControllableOutputTask() {
         git("tag", "-d", "base").runSilently(silenceErr = true)
         git("tag", "base").executeSilently()
 
-        applyGitPatches(git, target, output, patchDir.pathOrNull, printOutput.get(), verbose.get())
-
-        makeMcDevSrc(layout.cache, sourceMcDevJar.path, mcDevSources.path, outputDir.path, srcDir, dataDir)
+        try {
+            applyGitPatches(git, target, output, patchDir.pathOrNull, printOutput.get(), verbose.get())
+        } finally {
+            makeMcDevSrc(layout.cache, sourceMcDevJar.path, mcDevSources.path, outputDir.path, srcDir, dataDir)
+        }
     }
 }


### PR DESCRIPTION
Always create the mc dev sources folder in the server project while
applying patches, even if said patching failed.

This change allows full sources in IDE during version updates without
having to reload the project and rely on dependency resolution to
populate the dev sources folder.
