### PR TITLE
Allow selecting exactly n patches during roulette

### DIFF
--- a/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
@@ -68,6 +68,7 @@ testing {
             useKotlinTest(embeddedKotlinVersion)
             dependencies {
                 implementation("org.junit.jupiter:junit-jupiter-engine:5.10.1")
+                implementation("org.junit.jupiter:junit-jupiter-params:5.10.1")
                 implementation("org.junit.platform:junit-platform-launcher:1.10.1")
             }
 

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/AbstractPatchRouletteTask.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/AbstractPatchRouletteTask.kt
@@ -54,7 +54,7 @@ abstract class AbstractPatchRouletteTask : BaseTask() {
 
     override fun init() {
         super.init()
-        endpoint.convention("https://patch-roulette.papermc.io/api")
+        endpoint.convention("http://localhost:8080/api")
         authToken.convention(providers.gradleProperty("paperweight.patch-roulette-token"))
         doNotTrackState("Run when requested")
     }

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/AbstractPatchRouletteTask.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/AbstractPatchRouletteTask.kt
@@ -54,7 +54,7 @@ abstract class AbstractPatchRouletteTask : BaseTask() {
 
     override fun init() {
         super.init()
-        endpoint.convention("http://localhost:8080/api")
+        endpoint.convention("https://patch-roulette.papermc.io/api")
         authToken.convention(providers.gradleProperty("paperweight.patch-roulette-token"))
         doNotTrackState("Run when requested")
     }

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApply.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApply.kt
@@ -168,6 +168,10 @@ abstract class PatchRouletteApply : AbstractPatchRouletteTask() {
     sealed interface PatchSelectionStrategy {
         data class NumericInPackage(val count: Int, val enforceCount: Boolean = false) : PatchSelectionStrategy {
             override fun select(config: Config, available: List<Path>): Pair<Config, List<Path>> {
+                return this.select(config, available, this.count)
+            }
+
+            fun select(config: Config, available: List<Path>, count: Int): Pair<Config, List<Path>> {
                 if (config.suggestedPackage != null) {
                     val possiblePatches = available.filter { it.parent.equals(config.suggestedPackage) }.take(count)
                     if (possiblePatches.isNotEmpty()) {
@@ -180,14 +184,15 @@ abstract class PatchRouletteApply : AbstractPatchRouletteTask() {
                         // config, as the last suggested package is the one to suggest in potentially next runs.
                         val additionalPatches = select(
                             config.copy(suggestedPackage = null),
-                            available.filter { !possiblePatches.contains(it) }
+                            available.filter { !possiblePatches.contains(it) },
+                            count - possiblePatches.size
                         )
 
                         return additionalPatches.first to possiblePatches + additionalPatches.second
                     }
                 }
 
-                return select(config.copy(suggestedPackage = available.first().parent), available)
+                return select(config.copy(suggestedPackage = available.first().parent), available, count)
             }
         }
 

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApply.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApply.kt
@@ -38,6 +38,19 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.options.Option
 
+/**
+ * Patch roulette apply allows selection a set of patches from the remote patch roulette instance to work on.
+ * To control the amount/strategy of selecting these patches, the `--select` option can be passed.
+ * The following options are available:
+ *   - `n`:  Any positive integer number.
+ *           Paperweight will select *up to* `n` patches from the current package the user is working in.
+ *           If the package offers 0 patches, a new package will be chosen.
+ *           If the package offers `m` patches, and `m < n`, only `m` patches will be returned.
+ *   - `n!`: Any positive integer number followed by a `!`.
+ *           Paperweight will select `n` patches, prioritizing patches in the current package.
+ *           The only time less than `n` patches will be selected is if the entire patch roulette
+ *           instance has less than `n` patches available, in which case all of them will be selected.
+ */
 abstract class PatchRouletteApply : AbstractPatchRouletteTask() {
 
     @get:InputDirectory

--- a/paperweight-core/src/test/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApplyTest.kt
+++ b/paperweight-core/src/test/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApplyTest.kt
@@ -115,6 +115,29 @@ class PatchRouletteApplyTest {
                     ),
                 )
             ),
+            Arguments.of(
+                PatchRouletteApply.PatchSelectionStrategy.NumericInPackage(4, true),
+                listOf(
+                    "io/papermc/paper/block/Block.java",
+                    "io/papermc/paper/block/BlockData.java",
+                    "io/papermc/paper/block/BlockState.java",
+                    "io/papermc/paper/entity/Entity.java",
+                    "io/papermc/paper/entity/Entity2.java",
+                    "io/papermc/paper/entity/Entity3.java"
+                ),
+                listOf(
+                    listOf(
+                        "io/papermc/paper/block/Block.java",
+                        "io/papermc/paper/block/BlockData.java",
+                        "io/papermc/paper/block/BlockState.java",
+                        "io/papermc/paper/entity/Entity.java",
+                    ),
+                    listOf(
+                        "io/papermc/paper/entity/Entity2.java",
+                        "io/papermc/paper/entity/Entity3.java"
+                    )
+                )
+            )
         )
 
         fun mockAvailablePatches() = listOf(

--- a/paperweight-core/src/test/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApplyTest.kt
+++ b/paperweight-core/src/test/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApplyTest.kt
@@ -1,0 +1,127 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2023 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.core.tasks.patchroulette
+
+import kotlin.io.path.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class PatchRouletteApplyTest {
+
+    @Test
+    fun `test patch strategy parsing non enforced`() {
+        val strategy = PatchRouletteApply.PatchSelectionStrategy.parse("10")
+        when (strategy) {
+            is PatchRouletteApply.PatchSelectionStrategy.NumericInPackage -> {
+                assertEquals(10, strategy.count)
+                assertFalse(strategy.enforceCount)
+            }
+        }
+    }
+
+    @Test
+    fun `test patch strategy parsing enforced`() {
+        val strategy = PatchRouletteApply.PatchSelectionStrategy.parse("20!")
+        when (strategy) {
+            is PatchRouletteApply.PatchSelectionStrategy.NumericInPackage -> {
+                assertEquals(20, strategy.count)
+                assertTrue(strategy.enforceCount)
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testPatchSelectionSource")
+    fun `test patch selection`(
+        strategy: PatchRouletteApply.PatchSelectionStrategy,
+        allPatches: List<String>,
+        expectedPatchBatches: List<List<String>>
+    ) {
+        var config = PatchRouletteApply.Config(listOf(), null, listOf())
+        var availablePatches = allPatches.map { Path(it) }
+        for (batch in expectedPatchBatches) {
+            val selectionResult = strategy.select(config, availablePatches)
+            assertEquals(batch.map { Path(it) }, selectionResult.second)
+
+            config = selectionResult.first
+            availablePatches = availablePatches - selectionResult.second
+        }
+
+        assertTrue(availablePatches.isEmpty(), "Patches remained after exhausting expected batches")
+    }
+
+    companion object {
+        @JvmStatic
+        fun testPatchSelectionSource(): Collection<Arguments> = listOf(
+            Arguments.of(
+                PatchRouletteApply.PatchSelectionStrategy.NumericInPackage(2),
+                mockAvailablePatches(),
+                listOf(
+                    listOf("io/papermc/paper/block/Block.java", "io/papermc/paper/block/BlockData.java"),
+                    listOf("io/papermc/paper/block/BlockState.java"),
+                    listOf("io/papermc/paper/entity/Entity.java")
+                )
+            ),
+            Arguments.of(
+                PatchRouletteApply.PatchSelectionStrategy.NumericInPackage(5),
+                mockAvailablePatches(),
+                listOf(
+                    listOf("io/papermc/paper/block/Block.java", "io/papermc/paper/block/BlockData.java", "io/papermc/paper/block/BlockState.java"),
+                    listOf("io/papermc/paper/entity/Entity.java")
+                )
+            ),
+            Arguments.of(
+                PatchRouletteApply.PatchSelectionStrategy.NumericInPackage(2, true),
+                mockAvailablePatches(),
+                listOf(
+                    listOf("io/papermc/paper/block/Block.java", "io/papermc/paper/block/BlockData.java"),
+                    listOf("io/papermc/paper/block/BlockState.java", "io/papermc/paper/entity/Entity.java"),
+                )
+            ),
+            Arguments.of(
+                PatchRouletteApply.PatchSelectionStrategy.NumericInPackage(5, true),
+                mockAvailablePatches(),
+                listOf(
+                    listOf(
+                        "io/papermc/paper/block/Block.java",
+                        "io/papermc/paper/block/BlockData.java",
+                        "io/papermc/paper/block/BlockState.java",
+                        "io/papermc/paper/entity/Entity.java"
+                    ),
+                )
+            ),
+        )
+
+        fun mockAvailablePatches() = listOf(
+            "io/papermc/paper/block/Block.java",
+            "io/papermc/paper/block/BlockData.java",
+            "io/papermc/paper/block/BlockState.java",
+            "io/papermc/paper/entity/Entity.java"
+        )
+    }
+}


### PR DESCRIPTION
The package local implementation of the selection strategy works well
for large updates as single packages offer a great "unit" of patches to
work on.

When updating paper to specific snapshots on a weekly basis, generally
the amount of non-applicable patches is a lot lower. Being restricted to
a package in this case is bad dx, as most time is spent selecting more
patches and finishing them, when 10 patches would be a much better
"unit" of patches than a package with a single failed patch.
