### PR TITLE
Make SetupMinecraftSources cacheable

### DIFF
--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/DevBundleTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/DevBundleTasks.kt
@@ -64,7 +64,7 @@ class DevBundleTasks(
                 .getByName("main")
                 .allJava
         )
-        vanillaJavaDir.set(coreTasks.setupMacheSourcesForDevBundle.flatMap { it.outputDir })
+        vanillaJavaDir.set(coreTasks.extractMacheSourcesForDevBundle.flatMap { it.outputDir })
 
         minecraftVersion.set(project.coreExt.minecraftVersion)
         mojangMappedPaperclipFile.set(paperclipForDevBundle.flatMap { it.outputZip })

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ExtractMinecraftSources.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ExtractMinecraftSources.kt
@@ -1,0 +1,49 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2023 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.core.tasks
+
+import io.papermc.paperweight.tasks.BaseTask
+import io.papermc.paperweight.util.deleteRecursive
+import io.papermc.paperweight.util.path
+import io.papermc.paperweight.util.unzip
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+// To make the Git repos cacheable they must be zipped, this tasks extracts them again...
+abstract class ExtractMinecraftSources : BaseTask() {
+    @get:InputFile
+    abstract val zip: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @TaskAction
+    fun run() {
+        val output = outputDir.path
+        output.deleteRecursive()
+        unzip(zip, output)
+    }
+}

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupMinecraftSources.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupMinecraftSources.kt
@@ -46,7 +46,8 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.*
 
-abstract class SetupMinecraftSources : JavaLauncherTask() {
+@CacheableTask
+abstract class SetupMinecraftSources : JavaLauncherZippedTask() {
 
     @get:PathSensitive(PathSensitivity.NONE)
     @get:InputFile
@@ -55,11 +56,9 @@ abstract class SetupMinecraftSources : JavaLauncherTask() {
     @get:Internal
     abstract val predicate: Property<Predicate<Path>>
 
-    @get:OutputDirectory
-    abstract val outputDir: DirectoryProperty
-
     @get:Optional
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val libraryImports: DirectoryProperty
 
     @get:Optional
@@ -75,12 +74,10 @@ abstract class SetupMinecraftSources : JavaLauncherTask() {
 
     @get:InputFile
     @get:Optional
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val atFile: RegularFileProperty
 
-    @TaskAction
-    fun run() {
-        val outputPath = outputDir.convertToPath()
-
+    override fun run(outputPath: Path) {
         val git: Git
         if (oldPaperCommit.isPresent) {
             val oldPaperDir = setupOldPaper()

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ExtractFromBundler.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/ExtractFromBundler.kt
@@ -29,13 +29,11 @@ import java.nio.file.Path
 import kotlin.io.path.*
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
-@CacheableTask
 abstract class ExtractFromBundler : BaseTask() {
 
     @get:Classpath


### PR DESCRIPTION
To preserve the Git repo integrity we must zip the outputs ourselves