### PR TITLE
Change default single file patch apply mode to OFFSET

### DIFF
--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplySingleFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplySingleFilePatches.kt
@@ -100,7 +100,7 @@ abstract class ApplySingleFilePatches : BaseTask() {
 
     override fun init() {
         super.init()
-        mode.convention(PatchMode.EXACT)
+        mode.convention(PatchMode.OFFSET)
         minFuzz.convention(providers.defaultMinFuzz())
     }
 


### PR DESCRIPTION
Currently this task is used only for forks and the `EXACT` mode used right now causes a lot of maintenance burden and issues on every tiny change to the build files by paper. This brings its behavior to match source patches

More information here on discord: https://discord.com/channels/289587909051416579/1078993196924813372/1395974373160255529

before:
<img width="613" height="248" alt="image777" src="https://github.com/user-attachments/assets/caa48c68-cc1a-43bd-947e-0d0c8099ae8f" />
after: (no issues, clean apply)
