### PR TITLE
chore: fix full vanilla test

### DIFF
--- a/paperweight-core/src/test/resources/functional_test/test-server/build.gradle
+++ b/paperweight-core/src/test/resources/functional_test/test-server/build.gradle
@@ -41,6 +41,11 @@ paperweight {
             additionalAts.set(file('../build-data/fake.at'))
         }
     } else {
+        paper {
+            sourcePatchDir.set(file('patches/sources'))
+            resourcePatchDir.set(file('patches/resources'))
+            featurePatchDir.set(file('patches/features'))
+        }
         minecraftVersion = '1.21.4'
     }
 }


### PR DESCRIPTION
This fixes an issue where the patches didn't get applied on top of the source in the `test full vanilla project` test due to not being configured, defeating its purpose

[note: it should be also possible to just change the directories etc and not change the build files but with such a trivial thing any approach is okay)