### PR TITLE
Do not prune tags when rebuilding patches

### DIFF
--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/RebuildGitPatches.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/tasks/RebuildGitPatches.kt
@@ -94,7 +94,7 @@ abstract class RebuildGitPatches : ControllableOutputTask() {
         }
 
         val git = Git(inputDir.path)
-        git("fetch", "--all", "--prune").runSilently(silenceErr = true)
+        git("fetch", "--all", "--prune", "--no-prune-tags").runSilently(silenceErr = true)
         git(
             "format-patch",
             "--diff-algorithm=myers", "--zero-commit", "--full-index", "--no-signature", "--no-stat", "-N",


### PR DESCRIPTION
A semi-common git config to set globally is fetch.pruneTags which allows
developers to prune tags no longer present on the remote.

This config however breaks patch rebuilding as the file and base tags
are pruned during the pruning fetch of paperweight prior to the
format-patch command.

To prevent this, this commit now explicitly disables patch pruning while
preparing the rebuild.
