### PR TITLE
feat: improve reobf task logic

### DIFF
--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/ReobfArtifactConfiguration.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/ReobfArtifactConfiguration.kt
@@ -61,9 +61,12 @@ fun interface ReobfArtifactConfiguration {
             }
 
             reobfJar {
+                dependsOn(devJarTask)
                 inputJar.set(devJarTask.flatMap { it.archiveFile })
                 outputJar.convention(archivesName(project).flatMap { layout.buildDirectory.file("libs/$it-${project.version}.jar") })
             }
+
+            project.tasks["assemble"].dependsOn(reobfJar)
         }
 
         /**
@@ -80,6 +83,7 @@ fun interface ReobfArtifactConfiguration {
                 project.tasks.named<AbstractArchiveTask>(JavaPlugin.JAR_TASK_NAME)
             }
             reobfJar {
+                dependsOn(devJarTask)
                 inputJar.set(devJarTask.flatMap { it.archiveFile })
                 outputJar.convention(archivesName(project).flatMap { layout.buildDirectory.file("libs/$it-${project.version}-reobf.jar") })
             }


### PR DESCRIPTION
- make reobf depend on dev jar task (not doing this breaks `assemble.dependsOn(reobfJar)`)
- make assemble depend on reobf for REOBF_PRODUCTION (makes sense as default behavior - if you need reobf-ed production, `build` should generate that jar)