### PR TITLE
fix(deps): adapt shadow configuration for shadow 9.x and bump shadow to 9.2.2

### DIFF
--- a/buildSrc/src/main/kotlin/config-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/config-publish.gradle.kts
@@ -27,6 +27,7 @@ configurations.shadowRuntimeElements {
 
 fun ShadowJar.configureStandard() {
     configurations = listOf(shade)
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 
     dependencies {
         exclude(dependency("org.jetbrains.kotlin:.*:.*"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ mockk = "io.mockk:mockk:1.14.5"
 # Gradle
 gradle-licenser = "net.kyori:indra-licenser-spotless:3.2.0"
 gradle-spotless = "com.diffplug.spotless:spotless-plugin-gradle:7.2.1"
-gradle-shadow = "com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:8.3.9"
+gradle-shadow = "com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.2.2"
 gradle-kotlin-dsl = "org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:6.2.0"
 gradle-plugin-kotlin = { module = "org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin" }
 gradle-plugin-publish = "com.gradle.publish:plugin-publish-plugin:2.0.0"


### PR DESCRIPTION
fixes https://github.com/PaperMC/paperweight/issues/355
since shadow 9.x, the `INCLUDE` duplication strategy has to be specified in order to properly merge service files

from [this shadow issue](https://github.com/GradleUp/shadow/issues/1785#issuecomment-3336144031)
```
duplicatesStrategy = DuplicatesStrategy.INCLUDE
must be set for
mergeServicesFiles()
to work properly. Once this is set, it worked properly.
```