### PR TITLE
Allow AT'ing library files

### DIFF
--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/CoreTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/CoreTasks.kt
@@ -88,6 +88,7 @@ class CoreTasks(
 
     val importLibraryFiles = tasks.register<ImportLibraryFiles>("importPaperLibraryFiles") {
         patches.from(project.coreExt.paper.sourcePatchDir, project.coreExt.paper.featurePatchDir)
+        atFile.set(mergePaperATs.flatMap { it.outputFile })
         devImports.set(project.coreExt.paper.devImports.fileExists())
         libraryFileIndex.set(indexLibraryFiles.flatMap { it.outputFile })
         libraries.from(indexLibraryFiles.map { it.libraries })

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/MinecraftPatchingTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/MinecraftPatchingTasks.kt
@@ -155,6 +155,7 @@ class MinecraftPatchingTasks(
 
         val importLibFiles = tasks.register<ImportLibraryFiles>("import${configName.capitalized()}LibraryFiles") {
             patches.from(config.featurePatchDir, config.sourcePatchDir)
+            atFile.set(mergeCollectedAts.flatMap { it.outputFile })
             devImports.set(config.devImports.fileExists())
             libraryFileIndex.set(coreTasks.indexLibraryFiles.flatMap { it.outputFile })
             libraries.from(coreTasks.indexLibraryFiles.map { it.libraries })

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ImportLibraryFiles.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ImportLibraryFiles.kt
@@ -109,6 +109,10 @@ abstract class ImportLibraryFiles : BaseTask() {
 
     @get:Optional
     @get:InputFile
+    abstract val atFile: RegularFileProperty
+
+    @get:Optional
+    @get:InputFile
     abstract val devImports: RegularFileProperty
 
     @get:OutputDirectory
@@ -131,6 +135,7 @@ abstract class ImportLibraryFiles : BaseTask() {
             ioDispatcher("ImportLibraryFiles").use { dispatcher ->
                 importLibraryFiles(
                     patchFiles,
+                    atFile.pathOrNull,
                     devImports.pathOrNull,
                     outputDir.path,
                     libraries.sourcesJars(),
@@ -144,6 +149,7 @@ abstract class ImportLibraryFiles : BaseTask() {
 
     private fun importLibraryFiles(
         patches: Iterable<Path>,
+        atFile: Path?,
         importsFile: Path?,
         targetDir: Path,
         libFiles: List<Path>,
@@ -152,7 +158,7 @@ abstract class ImportLibraryFiles : BaseTask() {
         dispatcher: CoroutineDispatcher,
     ) = runBlocking {
         // Import library classes
-        val allImports = findLibraryImports(importsFile, libFiles, index, patches, dispatcher)
+        val allImports = findLibraryImports(importsFile, libFiles, index, patches, atFile, dispatcher)
         val importsByLib = allImports.groupBy { it.libraryFileName }
         logger.log(if (printOutput) LogLevel.LIFECYCLE else LogLevel.DEBUG, "Importing {} classes from library sources...", allImports.size)
 
@@ -191,6 +197,7 @@ abstract class ImportLibraryFiles : BaseTask() {
         libFiles: List<Path>,
         index: Set<LibraryImport>,
         patchFiles: Iterable<Path>,
+        atFile: Path?,
         dispatcher: CoroutineDispatcher,
     ): Set<LibraryImport> {
         val result = hashSetOf<LibraryImport>()
@@ -207,14 +214,15 @@ abstract class ImportLibraryFiles : BaseTask() {
                 }
         }
 
-        // Scan patches for necessary imports
-        result += findNeededLibraryImports(patchFiles, index, dispatcher)
+        // Scan patches and the AT file for necessary imports
+        result += findNeededLibraryImports(patchFiles, atFile, index, dispatcher)
 
         return result
     }
 
     private suspend fun findNeededLibraryImports(
         patchFiles: Iterable<Path>,
+        atFile: Path?,
         index: Set<LibraryImport>,
         dispatcher: CoroutineDispatcher,
     ): Set<LibraryImport> {
@@ -230,6 +238,19 @@ abstract class ImportLibraryFiles : BaseTask() {
             if (value != null) {
                 needed += value
             }
+        }
+        atFile?.useLines { lines ->
+            lines.filterNot { it.startsWith("#") }
+                .forEach { line ->
+                    val parts = line.split(' ')
+                    if (parts.size < 2) return@forEach
+                    val className = parts[1]
+                    val key = className.replace('.', '/').substringBefore('$') + ".java"
+                    val value = knownImportMap[key]
+                    if (value != null) {
+                        needed += value
+                    }
+                }
         }
         return needed
     }

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupForkMinecraftSources.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupForkMinecraftSources.kt
@@ -78,18 +78,6 @@ abstract class SetupForkMinecraftSources : JavaLauncherTask() {
 
         val git = Git.open(outputDir.path.toFile())
 
-        if (atFile.isPresent && atFile.path.readText().isNotBlank()) {
-            println("Applying access transformers...")
-            ats.run(
-                launcher.get(),
-                inputDir.path,
-                outputDir.path,
-                atFile.path,
-                atWorkingDir.path,
-            )
-            commitAndTag(git, "ATs", "${identifier.get()} ATs")
-        }
-
         if (libraryImports.isPresent) {
             libraryImports.path.walk().forEach {
                 val outFile = out.resolve(it.relativeTo(libraryImports.path).invariantSeparatorsPathString)
@@ -100,6 +88,18 @@ abstract class SetupForkMinecraftSources : JavaLauncherTask() {
             }
 
             commitAndTag(git, "Imports", "${identifier.get()} Imports")
+        }
+
+        if (atFile.isPresent && atFile.path.readText().isNotBlank()) {
+            println("Applying access transformers...")
+            ats.run(
+                launcher.get(),
+                outputDir.path,
+                outputDir.path,
+                atFile.path,
+                atWorkingDir.path,
+            )
+            commitAndTag(git, "ATs", "${identifier.get()} ATs")
         }
 
         git.close()

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupMinecraftSources.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupMinecraftSources.kt
@@ -174,6 +174,14 @@ abstract class SetupMinecraftSources : JavaLauncherZippedTask() {
             logger.lifecycle("Applied ${result.summary.changedFiles} mache patches")
         }
 
+        if (libraryImports.isPresent) {
+            libraryImports.path.copyRecursivelyTo(outputPath)
+
+            if (!oldPaperCommit.isPresent) {
+                commitAndTag(git, "Imports", "paper Imports")
+            }
+        }
+
         if (atFile.isPresent) {
             println("Applying access transformers...")
             ats.run(
@@ -189,13 +197,7 @@ abstract class SetupMinecraftSources : JavaLauncherZippedTask() {
         }
 
         if (oldPaperCommit.isPresent) {
-            commitAndTag(git, "Vanilla", "Vanilla, Mache, & paper ATs (Squashed for better Git history during updates)")
-        }
-
-        if (libraryImports.isPresent) {
-            libraryImports.path.copyRecursivelyTo(outputPath)
-
-            commitAndTag(git, "Imports", "paper Imports")
+            commitAndTag(git, "Vanilla", "Vanilla, Mache, paper Imports & paper ATs (Squashed for better Git history during updates)")
         }
 
         git.close()


### PR DESCRIPTION
This will also auto-import the library files that have ATs defined for them and the logic has been tested in production in a `fork-of-a-fork` setup.

Wasn't sure how exactly to order this inside of `SetupMinecraftSources.kt` so some input would be useful.