### PR TITLE
feat: add a fixup feature patches task

### DIFF
--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/MinecraftPatchingTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/MinecraftPatchingTasks.kt
@@ -28,6 +28,7 @@ import io.papermc.paperweight.core.tasks.SetupForkMinecraftSources
 import io.papermc.paperweight.core.tasks.patching.ApplyFeaturePatches
 import io.papermc.paperweight.core.tasks.patching.ApplyFilePatches
 import io.papermc.paperweight.core.tasks.patching.ApplyFilePatchesFuzzy
+import io.papermc.paperweight.core.tasks.patching.FixupFeaturePatches
 import io.papermc.paperweight.core.tasks.patching.FixupFilePatches
 import io.papermc.paperweight.core.tasks.patching.RebuildFilePatches
 import io.papermc.paperweight.tasks.*
@@ -261,6 +262,15 @@ class MinecraftPatchingTasks(
 
             repo.set(outputResources)
             upstream.set("upstream/main")
+        }
+
+        val fixupFeaturePatches = tasks.register<FixupFeaturePatches>("fixup${namePart}FeaturePatches") {
+            group()
+            description = "Puts the currently tracked source changes into the specified $configName Minecraft feature patch commit"
+
+            repo.set(outputSrc)
+            upstream.set("upstream/main")
+            patches.set(featurePatchDir)
         }
 
         val applyOrMoveSourcePatches = tasks.register<ApplyFilePatches>("applyOrMove${namePart}SourcePatches") {

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/MinecraftPatchingTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/MinecraftPatchingTasks.kt
@@ -269,7 +269,7 @@ class MinecraftPatchingTasks(
             description = "Puts the currently tracked source changes into the specified $configName Minecraft feature patch commit"
 
             repo.set(outputSrc)
-            upstream.set("upstream/main")
+            upstream.set("file")
             patches.set(featurePatchDir)
         }
 

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/PatchingTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/PatchingTasks.kt
@@ -25,6 +25,7 @@ package io.papermc.paperweight.core.taskcontainers
 import io.papermc.paperweight.core.tasks.patching.ApplyFeaturePatches
 import io.papermc.paperweight.core.tasks.patching.ApplyFilePatches
 import io.papermc.paperweight.core.tasks.patching.ApplyFilePatchesFuzzy
+import io.papermc.paperweight.core.tasks.patching.FixupFeaturePatches
 import io.papermc.paperweight.core.tasks.patching.FixupFilePatches
 import io.papermc.paperweight.core.tasks.patching.RebuildFilePatches
 import io.papermc.paperweight.tasks.*
@@ -101,6 +102,7 @@ class PatchingTasks(
 
     val rebuildFilePatchesName = "rebuild${namePart}FilePatches"
     val fixupFilePatchesName = "fixup${namePart}FilePatches"
+    val fixupFeaturePatchesName = "fixup${namePart}FeaturePatches"
     val rebuildFeaturePatchesName = "rebuild${namePart}FeaturePatches"
     val rebuildPatchesName = "rebuild${namePart}Patches"
 
@@ -137,6 +139,15 @@ class PatchingTasks(
 
             repo.set(outputDir)
             upstream.set("base")
+        }
+
+        val fixupFeaturePatches = tasks.register<FixupFeaturePatches>(fixupFeaturePatchesName) {
+            group = taskGroup
+            description = "Puts the currently tracked source changes into the specified $patchSetName feature patch commit"
+
+            repo.set(outputDir)
+            upstream.set("base")
+            patches.set(featurePatchDir)
         }
 
         val rebuildFeaturePatches = tasks.register<RebuildGitPatches>(rebuildFeaturePatchesName) {

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/PatchingTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/PatchingTasks.kt
@@ -146,7 +146,7 @@ class PatchingTasks(
             description = "Puts the currently tracked source changes into the specified $patchSetName feature patch commit"
 
             repo.set(outputDir)
-            upstream.set("base")
+            upstream.set("file")
             patches.set(featurePatchDir)
         }
 

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/FixupFeaturePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/FixupFeaturePatches.kt
@@ -1,0 +1,83 @@
+/*
+ * paperweight is a Gradle plugin for the PaperMC project.
+ *
+ * Copyright (c) 2023 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.paperweight.core.tasks.patching
+
+import io.papermc.paperweight.tasks.*
+import io.papermc.paperweight.util.*
+import kotlin.io.path.listDirectoryEntries
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+import org.gradle.api.tasks.options.Option
+
+@UntrackedTask(because = "Always fixup when requested")
+abstract class FixupFeaturePatches : BaseTask() {
+
+    @get:InputDirectory
+    abstract val repo: DirectoryProperty
+
+    @get:Input
+    abstract val upstream: Property<String>
+
+    @get:InputDirectory
+    abstract val patches: DirectoryProperty
+
+    @get:Input
+    @get:Optional
+    @get:Option(option = "patch-number", description = "Select the patch to modify")
+    abstract val patchNumber: Property<Int>
+
+    @TaskAction
+    fun run() {
+        val git = Git(repo)
+        var index = -1
+        if (patchNumber.isPresent) {
+            index = patchNumber.get() - 1 // -1 as the commits index starts from 0 whereas patches start from 1
+        } else {
+            logger.lifecycle("===============================================")
+            logger.lifecycle("Please enter the patch number into which the current changes should be merged")
+            logger.lifecycle("===============================================")
+            val patches = patches.get().path.listDirectoryEntries("*.patch").toList().sortedBy { it.fileName.toString().substringBefore("-").toInt() }
+            logger.lifecycle("Possible patches:")
+            for (patch in patches) {
+                logger.lifecycle(patch.fileName.toString())
+            }
+            logger.lifecycle("===============================================")
+            while (index == -1) {
+                index = System.`in`.bufferedReader().readLine().toInt() - 1
+            }
+        }
+        val commits = git("rev-list", "file..HEAD").getText().trim().lines().filter { it.isNotBlank() }.reversed()
+        if (index < 0 || index >= commits.size) {
+            error("Patch index out of range: $index (size=${commits.size})")
+        }
+        val selectedCommit = commits[index]
+        git("add", ".").executeOut()
+        git("commit", "--fixup", selectedCommit).executeOut()
+        git("-c", "sequence.editor=:", "rebase", "-i", "--autosquash", upstream.get()).executeOut()
+    }
+}

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/FixupFeaturePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/FixupFeaturePatches.kt
@@ -54,7 +54,7 @@ abstract class FixupFeaturePatches : BaseTask() {
     @TaskAction
     fun run() {
         val git = Git(repo)
-        var index = -1
+        var index = Int.MIN_VALUE
         if (patchNumber.isPresent) {
             index = patchNumber.get() - 1 // -1 as the commits index starts from 0 whereas patches start from 1
         } else {
@@ -67,7 +67,7 @@ abstract class FixupFeaturePatches : BaseTask() {
                 logger.lifecycle(patch.fileName.toString())
             }
             logger.lifecycle("===============================================")
-            while (index == -1) {
+            while (index == Int.MIN_VALUE) {
                 index = System.`in`.bufferedReader().readLine().toInt() - 1
             }
         }


### PR DESCRIPTION
This PR adds a `fixup[source]FeaturePatches` task that works very similarly to the per-file fixup task, with the exception of needing to specify the patch, into which the changes should be merged into.
<img width="757" height="755" alt="image" src="https://github.com/user-attachments/assets/58a457c6-f94a-4cdd-88a4-e40c905a9f6a" />

The patch number can also be provided through the CLI, by using the `--patch-number` arg