### PR TITLE
Use gradle's lifecycle logger wherever applicable

### DIFF
--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupForkMinecraftSources.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupForkMinecraftSources.kt
@@ -79,7 +79,7 @@ abstract class SetupForkMinecraftSources : JavaLauncherTask() {
         val git = Git.open(outputDir.path.toFile())
 
         if (atFile.isPresent && atFile.path.readText().isNotBlank()) {
-            println("Applying access transformers...")
+            logger.lifecycle("Applying access transformers...")
             ats.run(
                 launcher.get(),
                 inputDir.path,

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupMinecraftSources.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupMinecraftSources.kt
@@ -123,7 +123,7 @@ abstract class SetupMinecraftSources : JavaLauncherZippedTask() {
             git.tag().setName("ROOT").setTagger(rootIdent).setSigned(false).call()
         }
 
-        println("Copy initial sources...")
+        logger.lifecycle("Copy initial sources...")
         inputFile.path.openZip().use { inputFileFs ->
             inputFileFs.walkSequence()
                 .filter(predicate.get()::test)
@@ -144,13 +144,13 @@ abstract class SetupMinecraftSources : JavaLauncherZippedTask() {
                 }
         }
 
-        println("Setup git repo...")
+        logger.lifecycle("Setup git repo...")
         if (!oldPaperCommit.isPresent) {
             commitAndTag(git, "Vanilla")
         }
 
         if (!mache.isEmpty) {
-            println("Applying mache patches...")
+            logger.lifecycle("Applying mache patches...")
 
             val result = PatchOperation.builder()
                 .logTo(LoggingOutputStream(logger, LogLevel.LIFECYCLE))
@@ -175,7 +175,7 @@ abstract class SetupMinecraftSources : JavaLauncherZippedTask() {
         }
 
         if (atFile.isPresent) {
-            println("Applying access transformers...")
+            logger.lifecycle("Applying access transformers...")
             ats.run(
                 launcher.get(),
                 outputPath,


### PR DESCRIPTION
This is done for consistency between different tasks and so that CLI log level args such as `--quiet` get respected.