### PR TITLE
Update gradle to 9.6.1

### DIFF
--- a/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
     }
     compilerOptions {
         jvmTarget = JvmTarget.JVM_17
-        freeCompilerArgs = listOf("-Xjvm-default=all", "-Xjdk-release=17")
+        freeCompilerArgs = listOf("-jvm-default=enable", "-Xjdk-release=17")
     }
 }
 
@@ -61,7 +61,7 @@ dependencies {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        val test = getByName<JvmTestSuite>("test") {
             useKotlinTest(embeddedKotlinVersion)
             dependencies {
                 implementation("org.junit.jupiter:junit-jupiter-engine:6.0.3")

--- a/buildSrc/src/main/kotlin/config-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/config-publish.gradle.kts
@@ -16,7 +16,7 @@ if (noRelocate) {
     }
 }
 
-val shade: Configuration by configurations.creating
+val shade = configurations.create("shade")
 configurations.implementation {
     extendsFrom(shade)
 }
@@ -41,7 +41,7 @@ fun ShadowJar.configureStandard() {
     mergeServiceFiles()
 }
 
-val sourcesJar by tasks.existing(AbstractArchiveTask::class) {
+val sourcesJar = tasks.named<AbstractArchiveTask>("sourcesJar") {
     from(
         zipTree(project(":paperweight-lib").tasks
             .named("sourcesJar", AbstractArchiveTask::class)
@@ -56,13 +56,13 @@ gradlePlugin {
     vcsUrl.set("https://github.com/PaperMC/paperweight")
 }
 
-val shadowJar by tasks.existing(ShadowJar::class) {
+val shadowJar = tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier.set(null as String?)
     configureStandard()
 
     inputs.property("noRelocate", noRelocate)
     if (noRelocate) {
-        return@existing
+        return@named
     }
 
     val prefix = "paper.libs"

--- a/buildSrc/src/main/kotlin/utils.kt
+++ b/buildSrc/src/main/kotlin/utils.kt
@@ -10,7 +10,7 @@ import org.gradle.plugin.devel.PluginDeclaration
 fun Configuration.compatibilityAttributes(objects: ObjectFactory) {
     attributes {
         attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
-        attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named("9.0.0"))
+        attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named("9.5.0"))
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ mockk = "io.mockk:mockk:1.14.9"
 gradle-licenser = "net.kyori:indra-licenser-spotless:4.0.0"
 gradle-spotless = "com.diffplug.spotless:spotless-plugin-gradle:8.1.0"
 gradle-shadow = "com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.3.2"
-gradle-kotlin-dsl = "org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:6.4.2"
+gradle-kotlin-dsl = "org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:6.6.4"
 gradle-plugin-kotlin = { module = "org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin" }
 gradle-plugin-publish = "com.gradle.publish:plugin-publish-plugin:2.0.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/PaperweightSourceGeneratorHelper.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/PaperweightSourceGeneratorHelper.kt
@@ -34,9 +34,9 @@ abstract class PaperweightSourceGeneratorHelper : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         val ext = extensions.create(PAPERWEIGHT_EXTENSION, PaperweightSourceGeneratorExt::class)
 
-        val minecraftJar by configurations.registering
+        val minecraftJar = configurations.register("minecraftJar")
 
-        val applyAts by tasks.registering<ApplyAccessTransform> {
+        val applyAts = tasks.register<ApplyAccessTransform>("applyAccessTransform") {
             inputJar.set(layout.file(minecraftJar.flatMap { it.elements }.map { it.single().asFile }))
             atFile.set(ext.atFile)
         }

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/checkstyle/PaperCheckstyle.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/checkstyle/PaperCheckstyle.kt
@@ -50,7 +50,7 @@ abstract class PaperCheckstyle : Plugin<Project> {
             toolVersion = LibraryVersions.CHECKSTYLE
         }
 
-        val mergeCheckstyleConfigs by target.tasks.registering<MergeCheckstyleConfigs>()
+        val mergeCheckstyleConfigs = target.tasks.register<MergeCheckstyleConfigs>("mergeCheckstyleConfigs")
 
         target.tasks.withType(PaperCheckstyleTask::class.java).configureEach {
             rootPath.convention(layout.settingsDirectory.asFile.path)

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/checkstyle/tasks/MergeCheckstyleConfigs.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/checkstyle/tasks/MergeCheckstyleConfigs.kt
@@ -37,28 +37,28 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.exists
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import org.xml.sax.InputSource
 
-@CacheableTask
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class MergeCheckstyleConfigs : BaseTask() {
 
     @get:InputFile
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val baseConfigFile: RegularFileProperty
 
     @get:InputFile
     @get:Optional
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val overrideConfigFile: RegularFileProperty
 
     @get:OutputFile

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/checkstyle/tasks/MergeCheckstyleConfigs.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/checkstyle/tasks/MergeCheckstyleConfigs.kt
@@ -37,22 +37,28 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.exists
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import org.xml.sax.InputSource
 
+@CacheableTask
 abstract class MergeCheckstyleConfigs : BaseTask() {
 
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val baseConfigFile: RegularFileProperty
 
     @get:InputFile
     @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val overrideConfigFile: RegularFileProperty
 
     @get:OutputFile

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/checkstyle/tasks/PaperCheckstyleTask.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/checkstyle/tasks/PaperCheckstyleTask.kt
@@ -31,12 +31,16 @@ import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 abstract class PaperCheckstyleTask : Checkstyle() {
 
     @get:Input
@@ -55,6 +59,7 @@ abstract class PaperCheckstyleTask : Checkstyle() {
 
     @get:InputFile
     @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val configOverride: RegularFileProperty
 
     @TaskAction

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/checkstyle/tasks/PaperCheckstyleTask.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/checkstyle/tasks/PaperCheckstyleTask.kt
@@ -31,7 +31,6 @@ import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Nested
@@ -39,8 +38,9 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
-@CacheableTask
+@UntrackedTask(because = "Tasks are run on demand via API calls")
 abstract class PaperCheckstyleTask : Checkstyle() {
 
     @get:Input
@@ -59,7 +59,7 @@ abstract class PaperCheckstyleTask : Checkstyle() {
 
     @get:InputFile
     @get:Optional
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val configOverride: RegularFileProperty
 
     @TaskAction

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/AllTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/AllTasks.kt
@@ -45,7 +45,7 @@ open class AllTasks(
     downloadService: Provider<DownloadService> = project.download
 ) : InitialTasks(project) {
 
-    val downloadMcLibrariesSources by tasks.registering<DownloadMcLibraries> {
+    val downloadMcLibrariesSources = tasks.register<DownloadMcLibraries>("downloadMcLibrariesSources") {
         mcLibrariesFile.set(extractFromBundler.flatMap { it.serverLibrariesTxt })
         repositories.set(listOf(MC_LIBRARY_URL, MAVEN_CENTRAL_URL))
         outputDir.set(cache.resolve(MINECRAFT_SOURCES_PATH))
@@ -54,7 +54,7 @@ open class AllTasks(
         downloader.set(downloadService)
     }
 
-    val downloadRuntimeClasspathSources by tasks.registering<DownloadPaperLibraries> {
+    val downloadRuntimeClasspathSources = tasks.register<DownloadPaperLibraries>("downloadRuntimeClasspathSources") {
         paperDependencies.set(
             project.configurations.named(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).map { configuration ->
                 val view = configuration.incoming.artifactView {

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/CoreTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/CoreTasks.kt
@@ -49,7 +49,7 @@ class CoreTasks(
 ) : AllTasks(project) {
     lateinit var paperPatchingTasks: MinecraftPatchingTasks
 
-    val macheRemapJar by tasks.registering(RunCodebook::class) {
+    val macheRemapJar = tasks.register<RunCodebook>("macheRemapJar") {
         serverJar.set(extractFromBundler.flatMap { it.serverJar })
 
         codebookArgs.set(mache.map { it.remapperArgs })
@@ -60,7 +60,7 @@ class CoreTasks(
         outputJar.set(layout.cache.resolve(FINAL_REMAPPED_CODEBOOK_JAR))
     }
 
-    val macheDecompileJar by tasks.registering(DecompileJar::class) {
+    val macheDecompileJar = tasks.register<DecompileJar>("macheDecompileJar") {
         inputJar.set(macheRemapJar.flatMap { it.outputJar })
         decompilerArgs.set(mache.map { it.decompilerArgs })
 
@@ -70,11 +70,11 @@ class CoreTasks(
         outputJar.set(layout.cache.resolve(FINAL_DECOMPILE_JAR))
     }
 
-    val collectPaperATsFromPatches by tasks.registering(CollectATsFromPatches::class) {
+    val collectPaperATsFromPatches = tasks.register<CollectATsFromPatches>("collectPaperATsFromPatches") {
         patchDir.set(project.coreExt.paper.featurePatchDir.fileExists())
     }
 
-    val mergePaperATs by tasks.registering<MergeAccessTransforms> {
+    val mergePaperATs = tasks.register<MergeAccessTransforms>("mergePaperATs") {
         firstFile.set(project.coreExt.paper.additionalAts.fileExists())
         secondFile.set(collectPaperATsFromPatches.flatMap { it.outputFile })
     }
@@ -100,7 +100,7 @@ class CoreTasks(
         predicate.set { Files.isRegularFile(it) && it.toString().endsWith(".java") }
     }
 
-    val setupMacheSources by tasks.registering(SetupMinecraftSources::class) {
+    val setupMacheSources = tasks.register<SetupMinecraftSources>("setupMacheSources") {
         description = "Setup Minecraft source dir (applying mache patches and paper ATs)."
         configureSetupMacheSources()
         libraryImports.set(importLibraryFiles.flatMap { it.outputDir })
@@ -111,23 +111,23 @@ class CoreTasks(
         ats.jst.from(project.configurations.named(JST_CONFIG))
     }
 
-    val extractMacheSources by tasks.registering(ExtractMinecraftSources::class) {
+    val extractMacheSources = tasks.register<ExtractMinecraftSources>("extractMacheSources") {
         zip.set(setupMacheSources.flatMap { it.outputZip })
         outputDir.set(layout.cache.resolve(BASE_PROJECT).resolve("sources"))
     }
 
-    val setupMacheSourcesForDevBundle by tasks.registering(SetupMinecraftSources::class) {
+    val setupMacheSourcesForDevBundle = tasks.register<SetupMinecraftSources>("setupMacheSourcesForDevBundle") {
         description = "Setup Minecraft source dir (applying mache patches)."
         configureSetupMacheSources()
         outputZip.set(layout.cache.resolve(BASE_PROJECT).resolve("sources_dev_bundle.zip"))
     }
 
-    val extractMacheSourcesForDevBundle by tasks.registering(ExtractMinecraftSources::class) {
+    val extractMacheSourcesForDevBundle = tasks.register<ExtractMinecraftSources>("extractMacheSourcesForDevBundle") {
         zip.set(setupMacheSourcesForDevBundle.flatMap { it.outputZip })
         outputDir.set(layout.cache.resolve(BASE_PROJECT).resolve("sources_dev_bundle"))
     }
 
-    val setupMacheResources by tasks.registering(SetupMinecraftSources::class) {
+    val setupMacheResources = tasks.register<SetupMinecraftSources>("setupMacheResources") {
         description = "Setup Minecraft resources dir"
 
         inputFile.set(extractFromBundler.flatMap { it.serverJar })
@@ -135,7 +135,7 @@ class CoreTasks(
         outputZip.set(layout.cache.resolve(BASE_PROJECT).resolve("resources.zip"))
     }
 
-    val extractMacheResources by tasks.registering(ExtractMinecraftSources::class) {
+    val extractMacheResources = tasks.register<ExtractMinecraftSources>("extractMacheResources") {
         zip.set(setupMacheResources.flatMap { it.outputZip })
         outputDir.set(layout.cache.resolve(BASE_PROJECT).resolve("resources"))
     }
@@ -162,7 +162,7 @@ class CoreTasks(
         }
 
         if (!hasFork) {
-            val setupPaperScript by project.tasks.registering(SetupPaperScript::class) {
+            val setupPaperScript = project.tasks.register<SetupPaperScript>("setupPaperScript") {
                 group = GENERAL_TASK_GROUP
                 description = "Creates a util script and installs it into path"
 

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/DevBundleTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/DevBundleTasks.kt
@@ -41,21 +41,21 @@ class DevBundleTasks(
     private val coreTasks: CoreTasks,
     tasks: TaskContainer = project.tasks,
 ) {
-    val serverBundlerForDevBundle by tasks.registering<CreateBundlerJar> {
+    val serverBundlerForDevBundle = tasks.register<CreateBundlerJar>("serverBundlerForDevBundle") {
         mainClass.set(project.coreExt.mainClass)
         paperclip.from(project.configurations.named(PAPERCLIP_CONFIG))
         serverLibrariesList.set(coreTasks.extractFromBundler.flatMap { it.serverLibrariesList })
         vanillaBundlerJar.set(coreTasks.downloadServerJar.flatMap { it.outputJar })
     }
 
-    val paperclipForDevBundle by tasks.registering<CreatePaperclipJar> {
+    val paperclipForDevBundle = tasks.register<CreatePaperclipJar>("paperclipForDevBundle") {
         bundlerJar.set(serverBundlerForDevBundle.flatMap { it.outputZip })
         libraryChangesJson.set(serverBundlerForDevBundle.flatMap { it.libraryChangesJson })
         originalBundlerJar.set(coreTasks.downloadServerJar.flatMap { it.outputJar })
         mcVersion.set(project.coreExt.minecraftVersion)
     }
 
-    val generateDevelopmentBundle by tasks.registering<GenerateDevBundle> {
+    val generateDevelopmentBundle = tasks.register<GenerateDevBundle>("generateDevelopmentBundle") {
         group = "bundling"
 
         devBundleFile.set(project.layout.buildDirectory.file("libs/paperweight-development-bundle-${project.version}.zip"))

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/InitialTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/InitialTasks.kt
@@ -44,7 +44,7 @@ open class InitialTasks(
     downloadService: Provider<DownloadService> = project.download
 ) {
 
-    val downloadMcManifest by tasks.registering<DownloadTask> {
+    val downloadMcManifest = tasks.register<DownloadTask>("downloadMcManifest") {
         url.set(project.coreExt.minecraftManifestUrl)
         outputFile.set(cache.resolve(MC_MANIFEST))
 
@@ -54,7 +54,7 @@ open class InitialTasks(
     }
     private val mcManifest = downloadMcManifest.flatMap { it.outputFile }.map { gson.fromJson<MinecraftManifest>(it) }
 
-    val downloadMcVersionManifest by tasks.registering<CacheableDownloadTask> {
+    val downloadMcVersionManifest = tasks.register<CacheableDownloadTask>("downloadMcVersionManifest") {
         url.set(
             mcManifest.zip(extension.minecraftVersion) { manifest, version ->
                 manifest.versions.first { it.id == version }.url
@@ -71,14 +71,14 @@ open class InitialTasks(
     }
     private val versionManifest = downloadMcVersionManifest.flatMap { it.outputFile }.map { gson.fromJson<MinecraftVersionManifest>(it) }
 
-    val downloadServerJar by tasks.registering<DownloadServerJar> {
+    val downloadServerJar = tasks.register<DownloadServerJar>("downloadServerJar") {
         downloadUrl.set(versionManifest.map { version -> version.serverDownload().url })
         expectedHash.set(versionManifest.map { version -> version.serverDownload().hash() })
 
         downloader.set(downloadService)
     }
 
-    val extractFromBundler by tasks.registering<ExtractFromBundler> {
+    val extractFromBundler = tasks.register<ExtractFromBundler>("extractFromBundler") {
         bundlerJar.set(downloadServerJar.flatMap { it.outputJar })
 
         versionJson.set(cache.resolve(SERVER_VERSION_JSON))

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ExtractMinecraftSources.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ExtractMinecraftSources.kt
@@ -28,18 +28,18 @@ import io.papermc.paperweight.util.path
 import io.papermc.paperweight.util.unzip
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
 // To make the Git repos cacheable they must be zipped, this tasks extracts them again...
-@CacheableTask
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class ExtractMinecraftSources : BaseTask() {
     @get:InputFile
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val zip: RegularFileProperty
 
     @get:OutputDirectory

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ExtractMinecraftSources.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ExtractMinecraftSources.kt
@@ -28,13 +28,18 @@ import io.papermc.paperweight.util.path
 import io.papermc.paperweight.util.unzip
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 // To make the Git repos cacheable they must be zipped, this tasks extracts them again...
+@CacheableTask
 abstract class ExtractMinecraftSources : BaseTask() {
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val zip: RegularFileProperty
 
     @get:OutputDirectory

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/FilterRepo.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/FilterRepo.kt
@@ -29,14 +29,19 @@ import org.eclipse.jgit.api.Git
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 abstract class FilterRepo : BaseTask() {
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val inputDir: DirectoryProperty
 
     @get:OutputDirectory
@@ -44,6 +49,7 @@ abstract class FilterRepo : BaseTask() {
 
     @get:InputDirectory
     @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val gitDir: DirectoryProperty
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/FilterRepo.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/FilterRepo.kt
@@ -29,7 +29,6 @@ import org.eclipse.jgit.api.Git
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
@@ -37,11 +36,12 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
-@CacheableTask
+@UntrackedTask(because = "Tasks are run on demand via API calls")
 abstract class FilterRepo : BaseTask() {
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val inputDir: DirectoryProperty
 
     @get:OutputDirectory
@@ -49,7 +49,7 @@ abstract class FilterRepo : BaseTask() {
 
     @get:InputDirectory
     @get:Optional
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val gitDir: DirectoryProperty
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ImportLibraryFiles.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ImportLibraryFiles.kt
@@ -39,18 +39,23 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 private data class LibraryImport(val libraryFileName: String, val importFilePath: String)
 
+@CacheableTask
 abstract class IndexLibraryFiles : BaseTask() {
 
     @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val libraries: ConfigurableFileCollection
 
     @get:OutputFile
@@ -95,20 +100,25 @@ abstract class IndexLibraryFiles : BaseTask() {
     }
 }
 
+@CacheableTask
 abstract class ImportLibraryFiles : BaseTask() {
 
     @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val libraries: ConfigurableFileCollection
 
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val libraryFileIndex: RegularFileProperty
 
     @get:Optional
     @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val patches: ConfigurableFileCollection
 
     @get:Optional
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val devImports: RegularFileProperty
 
     @get:OutputDirectory

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ImportLibraryFiles.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/ImportLibraryFiles.kt
@@ -39,7 +39,6 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
@@ -48,14 +47,15 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
 private data class LibraryImport(val libraryFileName: String, val importFilePath: String)
 
-@CacheableTask
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class IndexLibraryFiles : BaseTask() {
 
     @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val libraries: ConfigurableFileCollection
 
     @get:OutputFile
@@ -100,25 +100,25 @@ abstract class IndexLibraryFiles : BaseTask() {
     }
 }
 
-@CacheableTask
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class ImportLibraryFiles : BaseTask() {
 
     @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val libraries: ConfigurableFileCollection
 
     @get:InputFile
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val libraryFileIndex: RegularFileProperty
 
     @get:Optional
     @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val patches: ConfigurableFileCollection
 
     @get:Optional
     @get:InputFile
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val devImports: RegularFileProperty
 
     @get:OutputDirectory

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/RunNestedBuild.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/RunNestedBuild.kt
@@ -35,6 +35,8 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.internal.build.NestedRootBuildRunner
@@ -48,6 +50,7 @@ abstract class RunNestedBuild : BaseTask() {
     abstract val tasks: SetProperty<String>
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val projectDir: DirectoryProperty
 
     @get:Internal

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/RunNestedBuild.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/RunNestedBuild.kt
@@ -38,6 +38,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.internal.build.NestedRootBuildRunner
+import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.service.ServiceRegistry
 
 @UntrackedTask(because = "Nested build does it's own up-to-date checking")
@@ -72,7 +73,8 @@ abstract class RunNestedBuild : BaseTask() {
             "runNestedRootBuild",
             String::class.java,
             StartParameterInternal::class.java,
-            ServiceRegistry::class.java
-        ).invoke(null, null, params, services)
+            ServiceRegistry::class.java,
+            ClassPath::class.java
+        ).invoke(null, null, params, services, ClassPath.EMPTY)
     }
 }

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/RunNestedBuild.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/RunNestedBuild.kt
@@ -50,7 +50,7 @@ abstract class RunNestedBuild : BaseTask() {
     abstract val tasks: SetProperty<String>
 
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val projectDir: DirectoryProperty
 
     @get:Internal

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupForkMinecraftSources.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupForkMinecraftSources.kt
@@ -31,6 +31,7 @@ import org.eclipse.jgit.api.Git
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
@@ -38,12 +39,16 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.*
 
+@CacheableTask
 abstract class SetupForkMinecraftSources : JavaLauncherTask() {
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val inputDir: DirectoryProperty
 
     @get:OutputDirectory
@@ -57,10 +62,12 @@ abstract class SetupForkMinecraftSources : JavaLauncherTask() {
 
     @get:InputFile
     @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val atFile: RegularFileProperty
 
     @get:Optional
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val libraryImports: DirectoryProperty
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupForkMinecraftSources.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupForkMinecraftSources.kt
@@ -31,7 +31,6 @@ import org.eclipse.jgit.api.Git
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
@@ -42,13 +41,14 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.kotlin.dsl.*
 
-@CacheableTask
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class SetupForkMinecraftSources : JavaLauncherTask() {
 
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val inputDir: DirectoryProperty
 
     @get:OutputDirectory
@@ -62,12 +62,12 @@ abstract class SetupForkMinecraftSources : JavaLauncherTask() {
 
     @get:InputFile
     @get:Optional
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val atFile: RegularFileProperty
 
     @get:Optional
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val libraryImports: DirectoryProperty
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupPaperScript.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupPaperScript.kt
@@ -31,6 +31,8 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
@@ -48,6 +50,7 @@ abstract class SetupPaperScript : BaseTask() {
     abstract val scriptName: Property<String>
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val root: DirectoryProperty
 
     init {

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupPaperScript.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/SetupPaperScript.kt
@@ -50,7 +50,7 @@ abstract class SetupPaperScript : BaseTask() {
     abstract val scriptName: Property<String>
 
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val root: DirectoryProperty
 
     init {

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplyFeaturePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplyFeaturePatches.kt
@@ -29,7 +29,6 @@ import java.nio.file.Path
 import kotlin.io.path.*
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
@@ -37,13 +36,14 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
-@CacheableTask
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class ApplyFeaturePatches : ControllableOutputTask() {
 
     @get:InputDirectory
     @get:Optional
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val base: DirectoryProperty
 
     @get:OutputDirectory

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplyFeaturePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplyFeaturePatches.kt
@@ -29,6 +29,7 @@ import java.nio.file.Path
 import kotlin.io.path.*
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
@@ -37,10 +38,12 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 abstract class ApplyFeaturePatches : ControllableOutputTask() {
 
     @get:InputDirectory
     @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val base: DirectoryProperty
 
     @get:OutputDirectory

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplyFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplyFilePatches.kt
@@ -40,10 +40,9 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.options.Option
 
-@CacheableTask
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class ApplyFilePatches : BaseTask() {
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplyFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplyFilePatches.kt
@@ -40,8 +40,10 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.options.Option
 
+@CacheableTask
 abstract class ApplyFilePatches : BaseTask() {
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplySingleFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplySingleFilePatches.kt
@@ -39,7 +39,6 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
@@ -49,9 +48,10 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.kotlin.dsl.*
 
-@CacheableTask
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class ApplySingleFilePatches : BaseTask() {
 
     @get:Inject
@@ -89,7 +89,7 @@ abstract class ApplySingleFilePatches : BaseTask() {
         abstract val path: Property<String>
 
         @get:InputFile
-        @get:PathSensitive(PathSensitivity.RELATIVE)
+        @get:PathSensitive(PathSensitivity.NONE)
         val upstreamFile: RegularFileProperty = objects.fileProperty().convention(upstream.file(path))
 
         @get:OutputFile
@@ -100,7 +100,7 @@ abstract class ApplySingleFilePatches : BaseTask() {
 
         @get:InputFile
         @get:Optional
-        @get:PathSensitive(PathSensitivity.RELATIVE)
+        @get:PathSensitive(PathSensitivity.NONE)
         abstract val patchFile: RegularFileProperty
     }
 

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplySingleFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/ApplySingleFilePatches.kt
@@ -39,15 +39,19 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.*
 
+@CacheableTask
 abstract class ApplySingleFilePatches : BaseTask() {
 
     @get:Inject
@@ -85,6 +89,7 @@ abstract class ApplySingleFilePatches : BaseTask() {
         abstract val path: Property<String>
 
         @get:InputFile
+        @get:PathSensitive(PathSensitivity.RELATIVE)
         val upstreamFile: RegularFileProperty = objects.fileProperty().convention(upstream.file(path))
 
         @get:OutputFile
@@ -95,6 +100,7 @@ abstract class ApplySingleFilePatches : BaseTask() {
 
         @get:InputFile
         @get:Optional
+        @get:PathSensitive(PathSensitivity.RELATIVE)
         abstract val patchFile: RegularFileProperty
     }
 

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/FixupFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/FixupFilePatches.kt
@@ -37,7 +37,7 @@ import org.gradle.api.tasks.UntrackedTask
 abstract class FixupFilePatches : BaseTask() {
 
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val repo: DirectoryProperty
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/FixupFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/FixupFilePatches.kt
@@ -28,6 +28,8 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.UntrackedTask
 
@@ -35,6 +37,7 @@ import org.gradle.api.tasks.UntrackedTask
 abstract class FixupFilePatches : BaseTask() {
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val repo: DirectoryProperty
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/RebuildFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/RebuildFilePatches.kt
@@ -54,9 +54,11 @@ abstract class RebuildFilePatches : JavaLauncherTask() {
     abstract val verbose: Property<Boolean>
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val input: DirectoryProperty
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val base: DirectoryProperty
 
     @get:OutputDirectory
@@ -64,6 +66,7 @@ abstract class RebuildFilePatches : JavaLauncherTask() {
 
     @get:Optional
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val atFile: RegularFileProperty
 
     @get:Optional

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/RebuildFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/RebuildFilePatches.kt
@@ -54,11 +54,11 @@ abstract class RebuildFilePatches : JavaLauncherTask() {
     abstract val verbose: Property<Boolean>
 
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val input: DirectoryProperty
 
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val base: DirectoryProperty
 
     @get:OutputDirectory
@@ -66,7 +66,7 @@ abstract class RebuildFilePatches : JavaLauncherTask() {
 
     @get:Optional
     @get:InputFile
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val atFile: RegularFileProperty
 
     @get:Optional

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/RebuildSingleFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/RebuildSingleFilePatches.kt
@@ -32,7 +32,6 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
@@ -41,12 +40,13 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
-@CacheableTask
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class RebuildSingleFilePatches : BaseTask() {
 
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val upstream: DirectoryProperty
 
     @get:Nested
@@ -57,7 +57,7 @@ abstract class RebuildSingleFilePatches : BaseTask() {
         abstract val path: Property<String>
 
         @get:InputFile
-        @get:PathSensitive(PathSensitivity.RELATIVE)
+        @get:PathSensitive(PathSensitivity.NONE)
         abstract val outputFile: RegularFileProperty
 
         @get:OutputFile

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/RebuildSingleFilePatches.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patching/RebuildSingleFilePatches.kt
@@ -32,16 +32,21 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 abstract class RebuildSingleFilePatches : BaseTask() {
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val upstream: DirectoryProperty
 
     @get:Nested
@@ -52,6 +57,7 @@ abstract class RebuildSingleFilePatches : BaseTask() {
         abstract val path: Property<String>
 
         @get:InputFile
+        @get:PathSensitive(PathSensitivity.RELATIVE)
         abstract val outputFile: RegularFileProperty
 
         @get:OutputFile

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/AbstractPatchRouletteTask.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/AbstractPatchRouletteTask.kt
@@ -36,7 +36,9 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
+@UntrackedTask(because = "Tasks are run on demand via API calls")
 abstract class AbstractPatchRouletteTask : BaseTask() {
     @get:Inject
     abstract val providers: ProviderFactory

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/AbstractPatchRouletteTask.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/AbstractPatchRouletteTask.kt
@@ -38,7 +38,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.UntrackedTask
 
-@UntrackedTask(because = "Tasks are run on demand via API calls")
+@UntrackedTask(because = "Tasks are abstract class as base class of other tasks")
 abstract class AbstractPatchRouletteTask : BaseTask() {
     @get:Inject
     abstract val providers: ProviderFactory

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/ClearPatchRouletteList.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/ClearPatchRouletteList.kt
@@ -24,7 +24,7 @@ package io.papermc.paperweight.core.tasks.patchroulette
 
 import org.gradle.api.tasks.UntrackedTask
 
-@UntrackedTask(because = "Tasks are run on demand via API calls")
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class ClearPatchRouletteList : AbstractPatchRouletteTask() {
 
     override fun run() {

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/ClearPatchRouletteList.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/ClearPatchRouletteList.kt
@@ -22,6 +22,9 @@
 
 package io.papermc.paperweight.core.tasks.patchroulette
 
+import org.gradle.api.tasks.UntrackedTask
+
+@UntrackedTask(because = "Tasks are run on demand via API calls")
 abstract class ClearPatchRouletteList : AbstractPatchRouletteTask() {
 
     override fun run() {

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApply.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApply.kt
@@ -36,6 +36,9 @@ import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
 
 /**
@@ -54,9 +57,11 @@ import org.gradle.api.tasks.options.Option
  *           Paperweight will attempt to select exactly the provided patch paths.
  *           If any of the provided patches are not available, the task will fail.
  */
+@UntrackedTask(because = "Tasks are run on demand via API calls")
 abstract class PatchRouletteApply : AbstractPatchRouletteTask() {
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val patchDir: DirectoryProperty
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApply.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteApply.kt
@@ -57,11 +57,11 @@ import org.gradle.api.tasks.options.Option
  *           Paperweight will attempt to select exactly the provided patch paths.
  *           If any of the provided patches are not available, the task will fail.
  */
-@UntrackedTask(because = "Tasks are run on demand via API calls")
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class PatchRouletteApply : AbstractPatchRouletteTask() {
 
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val patchDir: DirectoryProperty
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteCancel.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteCancel.kt
@@ -30,8 +30,10 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
 
+@UntrackedTask(because = "Tasks are run on demand via API calls")
 abstract class PatchRouletteCancel : AbstractPatchRouletteTask() {
     @get:OutputFile
     abstract val config: RegularFileProperty

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteCancel.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteCancel.kt
@@ -33,7 +33,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
 
-@UntrackedTask(because = "Tasks are run on demand via API calls")
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class PatchRouletteCancel : AbstractPatchRouletteTask() {
     @get:OutputFile
     abstract val config: RegularFileProperty

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteFinish.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteFinish.kt
@@ -32,10 +32,15 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
 
+@UntrackedTask(because = "Tasks are run on demand via API calls")
 abstract class PatchRouletteFinish : AbstractPatchRouletteTask() {
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val patchDir: DirectoryProperty
 
     @get:OutputFile

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteFinish.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PatchRouletteFinish.kt
@@ -37,10 +37,10 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
 
-@UntrackedTask(because = "Tasks are run on demand via API calls")
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class PatchRouletteFinish : AbstractPatchRouletteTask() {
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val patchDir: DirectoryProperty
 
     @get:OutputFile

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PushPatchRouletteList.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PushPatchRouletteList.kt
@@ -26,10 +26,15 @@ import io.papermc.paperweight.util.*
 import kotlin.io.path.*
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.UntrackedTask
 
+@UntrackedTask(because = "Tasks are run on demand via API calls")
 abstract class PushPatchRouletteList : AbstractPatchRouletteTask() {
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val patchDir: DirectoryProperty
 
     override fun run() {

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PushPatchRouletteList.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/PushPatchRouletteList.kt
@@ -30,11 +30,11 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.UntrackedTask
 
-@UntrackedTask(because = "Tasks are run on demand via API calls")
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class PushPatchRouletteList : AbstractPatchRouletteTask() {
 
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val patchDir: DirectoryProperty
 
     override fun run() {

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/ShowPatchRouletteList.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/ShowPatchRouletteList.kt
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
 
-@UntrackedTask(because = "Tasks are run on demand via API calls")
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class ShowPatchRouletteList : AbstractPatchRouletteTask() {
 
     @get:Input

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/ShowPatchRouletteList.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/tasks/patchroulette/ShowPatchRouletteList.kt
@@ -25,8 +25,10 @@ package io.papermc.paperweight.core.tasks.patchroulette
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
 
+@UntrackedTask(because = "Tasks are run on demand via API calls")
 abstract class ShowPatchRouletteList : AbstractPatchRouletteTask() {
 
     @get:Input

--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/utils.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/utils.kt
@@ -57,7 +57,6 @@ import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import org.cadixdev.lorenz.merge.MergeResult
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.Directory
@@ -76,7 +75,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.TaskContainer
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
@@ -289,9 +287,6 @@ fun <T> emptyMergeResult(): MergeResult<T?> {
     @Suppress("UNCHECKED_CAST")
     return emptyMergeResult as MergeResult<T?>
 }
-
-inline fun <reified T : Task> TaskContainer.registering(noinline configuration: T.() -> Unit) = registering(T::class, configuration)
-inline fun <reified T : Task> TaskContainer.registering() = registering(T::class)
 
 enum class HashingAlgorithm(val algorithmName: String) {
     SHA256("SHA-256"),

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUser.kt
@@ -84,7 +84,7 @@ abstract class PaperweightUser : Plugin<Project> {
             parameters.projectPath.set(target.projectDir)
         }
 
-        val cleanCache by target.tasks.registering<Delete> {
+        val cleanCache = target.tasks.register<Delete>("cleanCache") {
             group = GENERAL_TASK_GROUP
             description = "Delete the project-local paperweight-userdev setup cache."
             delete(target.layout.cache)
@@ -127,7 +127,7 @@ abstract class PaperweightUser : Plugin<Project> {
 
         createConfigurations(target, target.provider { userdevSetup }, setupTask)
 
-        val reobfJar by target.tasks.registering<RemapJar> {
+        val reobfJar = target.tasks.register<RemapJar>("reobfJar") {
             group = GENERAL_TASK_GROUP
             description = "Remap the compiled plugin jar to Spigot's obfuscated runtime names."
 
@@ -204,7 +204,7 @@ abstract class PaperweightUser : Plugin<Project> {
             // Clean v1 shared caches
             cleanSharedCaches(this, sharedCacheRoot)
 
-            if (cleaningCache(cleanCache, cleanAll)) {
+            if (cleaningCache(cleanCache as TaskProvider<*>, cleanAll as TaskProvider<*>)) {
                 tasks.withType(UserdevSetupTask::class).configureEach {
                     doFirst { throw PaperweightException("Cannot run setup tasks when cleaning caches") }
                 }

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/UserdevSetupTask.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/UserdevSetupTask.kt
@@ -33,14 +33,18 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.services.ServiceReference
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.workers.WorkerExecutor
 
+@CacheableTask
 abstract class UserdevSetupTask : JavaLauncherTask() {
     @get:ServiceReference
     abstract val setupService: Property<UserdevSetup>
@@ -49,18 +53,21 @@ abstract class UserdevSetupTask : JavaLauncherTask() {
     abstract val workerExecutor: WorkerExecutor
 
     @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val devBundle: ConfigurableFileCollection
 
     @get:CompileClasspath
     abstract val decompilerConfig: ConfigurableFileCollection
 
     @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val paramMappingsConfig: ConfigurableFileCollection
 
     @get:CompileClasspath
     abstract val macheDecompilerConfig: ConfigurableFileCollection
 
     @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val macheConfig: ConfigurableFileCollection
 
     @get:CompileClasspath
@@ -70,9 +77,11 @@ abstract class UserdevSetupTask : JavaLauncherTask() {
     abstract val macheRemapperConfig: ConfigurableFileCollection
 
     @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val macheParamMappingsConfig: ConfigurableFileCollection
 
     @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val macheConstantsConfig: ConfigurableFileCollection
 
     @get:CompileClasspath

--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/UserdevSetupTask.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/internal/setup/UserdevSetupTask.kt
@@ -33,7 +33,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.services.ServiceReference
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
@@ -41,10 +40,11 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.workers.WorkerExecutor
 
-@CacheableTask
+@UntrackedTask(because = "Task has already been registered internally")
 abstract class UserdevSetupTask : JavaLauncherTask() {
     @get:ServiceReference
     abstract val setupService: Property<UserdevSetup>
@@ -53,21 +53,21 @@ abstract class UserdevSetupTask : JavaLauncherTask() {
     abstract val workerExecutor: WorkerExecutor
 
     @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val devBundle: ConfigurableFileCollection
 
     @get:CompileClasspath
     abstract val decompilerConfig: ConfigurableFileCollection
 
     @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val paramMappingsConfig: ConfigurableFileCollection
 
     @get:CompileClasspath
     abstract val macheDecompilerConfig: ConfigurableFileCollection
 
     @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val macheConfig: ConfigurableFileCollection
 
     @get:CompileClasspath
@@ -77,11 +77,11 @@ abstract class UserdevSetupTask : JavaLauncherTask() {
     abstract val macheRemapperConfig: ConfigurableFileCollection
 
     @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val macheParamMappingsConfig: ConfigurableFileCollection
 
     @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val macheConstantsConfig: ConfigurableFileCollection
 
     @get:CompileClasspath


### PR DESCRIPTION
Gradle 9.5 break a function when a new instance was called in `runNestedRootBuild` since they update the signature of method , see [gradle](https://github.com/gradle/gradle/blob/91bf077d1cab56b0338076a88e4676ca1d31c98a/subprojects/core/src/main/java/org/gradle/internal/build/NestedRootBuildRunner.java#L34)