### PR TITLE
Add export for jdk.internal.misc to silence joml warning in 26.3

### DIFF
--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/PaperclipTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/PaperclipTasks.kt
@@ -67,7 +67,10 @@ class PaperclipTasks(
 
             paperclip.from(configurations.named(PAPERCLIP_CONFIG))
             mainClass.set(mainClassString)
-            extraManifestMainAttributes.convention(mapOf("Enable-Native-Access" to "ALL-UNNAMED"))
+            extraManifestMainAttributes.convention(mapOf(
+                "Enable-Native-Access" to "ALL-UNNAMED",
+                "Add-Exports" to "java.base/jdk.internal.misc"
+            ))
 
             outputZip.set(layout.buildDirectory.file(jarName("bundler", classifier).map { "libs/$it" }))
         }

--- a/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/PaperclipTasks.kt
+++ b/paperweight-core/src/main/kotlin/io/papermc/paperweight/core/taskcontainers/PaperclipTasks.kt
@@ -67,10 +67,12 @@ class PaperclipTasks(
 
             paperclip.from(configurations.named(PAPERCLIP_CONFIG))
             mainClass.set(mainClassString)
-            extraManifestMainAttributes.convention(mapOf(
-                "Enable-Native-Access" to "ALL-UNNAMED",
-                "Add-Exports" to "java.base/jdk.internal.misc"
-            ))
+            extraManifestMainAttributes.convention(
+                mapOf(
+                    "Enable-Native-Access" to "ALL-UNNAMED",
+                    "Add-Exports" to "java.base/jdk.internal.misc"
+                )
+            )
 
             outputZip.set(layout.buildDirectory.file(jarName("bundler", classifier).map { "libs/$it" }))
         }


### PR DESCRIPTION
This will allow joml to use the newer unsafe class once it's bumped in the 26.3 update and silence the warning when it falls back to the old one