### PR TITLE
fix: retry after waiting for in-process file lock

### DIFF
--- a/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/file-lock.kt
+++ b/paperweight-lib/src/main/kotlin/io/papermc/paperweight/util/file-lock.kt
@@ -65,6 +65,7 @@ fun <R> withLock(
                     "Have been waiting on lock for '$lockFile' for ${waitedMs / 1000 / 60} minute(s).\n" +
                         "If this persists for an unreasonable length of time, kill this process, run './gradlew --stop', and then try again."
                 )
+                continue
             }
         }
         if (openCurrentJvm[normalized] !== lock) {


### PR DESCRIPTION
When the timed in-process lock attempt expires, retry the outer acquisition loop rather than proceeding without owning the lock.

This prevents attempting to unlock a lock that was not acquired.