### PR TITLE
Fix Gradle 10 registering() deprecation in userdev

### DIFF
--- a/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUser.kt
+++ b/paperweight-userdev/src/main/kotlin/io/papermc/paperweight/userdev/PaperweightUser.kt
@@ -84,7 +84,7 @@ abstract class PaperweightUser : Plugin<Project> {
             parameters.projectPath.set(target.projectDir)
         }
 
-        val cleanCache by target.tasks.registering<Delete> {
+        val cleanCache = target.tasks.register<Delete>("cleanCache") {
             group = GENERAL_TASK_GROUP
             description = "Delete the project-local paperweight-userdev setup cache."
             delete(target.layout.cache)
@@ -127,7 +127,7 @@ abstract class PaperweightUser : Plugin<Project> {
 
         createConfigurations(target, target.provider { userdevSetup }, setupTask)
 
-        val reobfJar by target.tasks.registering<RemapJar> {
+        val reobfJar = target.tasks.register<RemapJar>("reobfJar") {
             group = GENERAL_TASK_GROUP
             description = "Remap the compiled plugin jar to Spigot's obfuscated runtime names."
 


### PR DESCRIPTION
﻿## Summary
- Replace deprecated Kotlin DSL `by tasks.registering` with `tasks.register` for `cleanCache` and `reobfJar` in `PaperweightUser`.
- Clears the Gradle warning about the registering property delegate being removed in Gradle 10.

## Test plan
- [ ] Apply `io.papermc.paperweight.userdev` on Gradle 9.7+ with `--warning-mode all` and confirm the registering deprecation is gone
- [ ] Confirm `reobfJar` / `cleanCache` task names and behavior are unchanged
